### PR TITLE
Bugfix: put CLR to separate store

### DIFF
--- a/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/TrustCredentialAdapter.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/TrustCredentialAdapter.java
@@ -119,11 +119,13 @@ public class TrustCredentialAdapter {
             lstCertCrlStores.addAll(config.getAdditionalCerts());
 
             lstCertCrlStores.add(cert);
+            
+            CertStoreParameters csp = new CollectionCertStoreParameters(config.getCRLs());
+            CertStore crlStore = CertStore.getInstance("Collection", csp);
 
             final Collection<X509CRL> crls = config.getCRLs();
             if (crls != null && !crls.isEmpty()) {
                 revocationEnabled = true;
-                lstCertCrlStores.add(crls);
             }
 
             final CollectionCertStoreParameters ccsp = new CollectionCertStoreParameters(lstCertCrlStores);
@@ -140,6 +142,7 @@ public class TrustCredentialAdapter {
             final PKIXBuilderParameters params = new PKIXBuilderParameters(trust, targetConstraints);
 
             params.addCertStore(store);
+            params.addCertStore(crlStore);
 
             final CertPathBuilder cpb = CertPathBuilder.getInstance("PKIX", CertUtility.getBouncyCastleProvider());
 


### PR DESCRIPTION
Putting certificates and crls together into one keystore resulted cause bouncycastle to ignore the clr (due to a wrong cast within a nested object)


(Provide a general summary of your changes in the Title above.)

## Description

(Describe your changes in detail.).

## Related Issue

(This project only accepts pull requests related to open issues.
 If suggesting a new feature or change, please discuss it in an issue first.
 If fixing a bug, there should be an issue describing it with steps to reproduce.
(Please link to the issue here:)

## Motivation and Context

(Why is this change required? What problem does it solve?
 If it fixes an open issue, please link to the issue here.)

## How Has This Been Tested?

(Please describe in detail how you tested your changes.
 Include details of your testing environment, and the tests you ran to
 see how your change affects other areas of the code, etc.)

## Screenshots

(As far as appropriate)
