### PR TITLE
Change initialization of BouncyCatsle Provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,3 +107,7 @@ note: maintenance release with updated dependencies, an adjusted CI pipeline
 ### 2.6.6 (Sept 20 2023)
 
 fix: Add test credential generation, fix key usage in test credentials
+
+### 2.6.7 (Sept 28 2023)
+
+fix: Bouncy Castle Provider initialized within the component only if not already registered in the current process

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.siemens.pki</groupId>
 	<artifactId>CmpRaComponent</artifactId>
-	<version>2.6.6</version>
+	<version>2.6.7</version>
 	<packaging>jar</packaging>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/CertUtility.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/CertUtility.java
@@ -17,11 +17,7 @@
  */
 package com.siemens.pki.cmpracomponent.cryptoservices;
 
-import org.bouncycastle.asn1.ASN1Encoding;
-import org.bouncycastle.asn1.ASN1OctetString;
-import org.bouncycastle.asn1.DEROctetString;
-import org.bouncycastle.asn1.cmp.CMPCertificate;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import static com.siemens.pki.cmpracomponent.util.NullUtil.ifNotNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -41,8 +37,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-
-import static com.siemens.pki.cmpracomponent.util.NullUtil.ifNotNull;
+import org.bouncycastle.asn1.ASN1Encoding;
+import org.bouncycastle.asn1.ASN1OctetString;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.cmp.CMPCertificate;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 /**
  * A utility class for certificate handling

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/framework/TestCertUtility.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/framework/TestCertUtility.java
@@ -17,6 +17,7 @@
  */
 package com.siemens.pki.cmpracomponent.test.framework;
 
+import com.siemens.pki.cmpracomponent.cryptoservices.CertUtility;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,13 +27,10 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.*;
-
-import com.siemens.pki.cmpracomponent.cryptoservices.CertUtility;
 import org.bouncycastle.asn1.ASN1Encoding;
 import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.cmp.CMPCertificate;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/framework/TestCertUtility.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/framework/TestCertUtility.java
@@ -26,6 +26,8 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.*;
+
+import com.siemens.pki.cmpracomponent.cryptoservices.CertUtility;
 import org.bouncycastle.asn1.ASN1Encoding;
 import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.DEROctetString;
@@ -39,7 +41,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TestCertUtility {
 
-    public static final BouncyCastleProvider BOUNCY_CASTLE_PROVIDER = new BouncyCastleProvider();
+    public static final Provider BOUNCY_CASTLE_PROVIDER = CertUtility.getBouncyCastleProvider();
     private static final Logger LOGGER = LoggerFactory.getLogger(TestCertUtility.class);
 
     private static final char[] TRUSTSTORE_SECRET = "Unimportant password".toCharArray();


### PR DESCRIPTION
## Description

Bouncy Castle Provider was initialized as a static variable. This would mean that if another library or application already initialized the provider, it would be initialized twice. 

## Related Issue

No open issue.

## Motivation and Context

We are using the CMP-ra-component in a project that does GraalVM native compilation. We need the bouncy castle security provider instance to be initialized at build time so that the native-image build process works.
Referencing the instance created  by the CMP-ra-component is not possible because it pulls other classes into the build process which should be initialized at runtime. More information at: https://www.graalvm.org/latest/reference-manual/native-image/dynamic-features/JCASecurityServices/ see SecureRandom section.

## How Has This Been Tested?

Test suite runs correctly

## Screenshots

No screenshots
