### PR TITLE
Update OWASP dependency check plugin to version 9.0.7 using NVD API Key

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -56,8 +56,22 @@ jobs:
         with:
           java-version: 11
           distribution: 'temurin'
+      - name: Restore cached Maven dependencies
+        uses: actions/cache/restore@v3
+        with:
+          path: ~/.m2/repository
+          # Using datetime in cache key as OWASP database may change, without the pom changing
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Analyze dependencies
         env:
           NVD_API_KEY: ${{ secrets.NVD_TOKEN }}
         # this will run the OWASP dependency checker only
-        run: mvn -B verify -DskipTests -Dgpg.skip
+        run: mvn -B verify -DskipTests -DnvdApiKey=${{ secrets.NVD_TOKEN }} -Dgpg.skip
+      - name: Cache Maven dependencies
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -39,6 +39,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          NVD_API_KEY: ${{ secrets.NVD_TOKEN }}
         # note that we deliberately turn off the OWASP dependency checker here, it will run in a separate job,
         # such that its results can be viewed independently of what Sonar has to say
         run: |

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -56,22 +56,14 @@ jobs:
         with:
           java-version: 11
           distribution: 'temurin'
-      - name: Restore cached Maven dependencies
-        uses: actions/cache/restore@v3
+      - name: Cache Maven packages
+        uses: actions/cache@v3
         with:
-          path: ~/.m2/repository
-          # Using datetime in cache key as OWASP database may change, without the pom changing
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Analyze dependencies
         env:
           NVD_API_KEY: ${{ secrets.NVD_TOKEN }}
         # this will run the OWASP dependency checker only
         run: mvn -B verify -DskipTests -Dgpg.skip
-      - name: Cache Maven dependencies
-        uses: actions/cache/save@v3
-        if: always()
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -68,7 +68,7 @@ jobs:
         env:
           NVD_API_KEY: ${{ secrets.NVD_TOKEN }}
         # this will run the OWASP dependency checker only
-        run: mvn -B verify -DskipTests -DnvdApiKey=${{ secrets.NVD_TOKEN }} -Dgpg.skip
+        run: mvn -B verify -DskipTests -Dgpg.skip
       - name: Cache Maven dependencies
         uses: actions/cache/save@v3
         if: always()

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -39,7 +39,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          NVD_API_KEY: ${{ secrets.NVD_TOKEN }}
         # note that we deliberately turn off the OWASP dependency checker here, it will run in a separate job,
         # such that its results can be viewed independently of what Sonar has to say
         run: |
@@ -58,5 +57,7 @@ jobs:
           java-version: 11
           distribution: 'temurin'
       - name: Analyze dependencies
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_TOKEN }}
         # this will run the OWASP dependency checker only
         run: mvn -B verify -DskipTests -Dgpg.skip

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
 			<plugin>
 				<groupId>org.owasp</groupId>
 				<artifactId>dependency-check-maven</artifactId>
-				<version>8.4.3</version>
+				<version>9.0.4</version>
 				<executions>
 					<execution>
 						<goals>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
 				<executions>
 					<execution>
 						<goals>
-							<goal>check</goal>
+							<goal>aggregate</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -130,11 +130,11 @@
 			<plugin>
 				<groupId>org.owasp</groupId>
 				<artifactId>dependency-check-maven</artifactId>
-				<version>9.0.4</version>
+				<version>9.0.7</version>
 				<executions>
 					<execution>
 						<goals>
-							<goal>aggregate</goal>
+							<goal>check</goal>
 						</goals>
 					</execution>
 				</executions>


### PR DESCRIPTION
## Description

- Upgraded version of dependency-check from v.8.4.3 to v.9.0.4 in pom.xml
- Added NVD_API_KEY to GitHub Actions workflow

## Motivation and Context

Upgrading to 9.0.0 or later is mandatory; previous versions of dependency-check utilize the NVD data feeds which will be deprecated on Dec 15th, 2023. Versions earlier then 9.0.0 are no longer supported and could fail to work after Dec 15th, 2023.
(see: [Upgrade notice](https://github.com/jeremylong/DependencyCheck/?tab=readme-ov-file#900-upgrade-notice))


