### PR TITLE
Run dependabot monthly (not weekly)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       dependabot-dependency-updates:
         update-types:


### PR DESCRIPTION
To reduce communications noise, reduce the frequency of checks from weekly to monthly.