### PR TITLE
Add new licence checker rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<groupId>com.siemens.pki</groupId>
 	<artifactId>CmpRaComponent</artifactId>
 	<packaging>jar</packaging>
-	<version>4.1.0</version>
+	<version>4.1.1</version>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<parent.basedir>.</parent.basedir>
@@ -130,7 +130,7 @@
 			<plugin>
 				<groupId>org.owasp</groupId>
 				<artifactId>dependency-check-maven</artifactId>
-				<version>9.0.7</version>
+				<version>9.0.8</version>
 				<executions>
 					<execution>
 						<goals>

--- a/resources/allowed-licenses.txt
+++ b/resources/allowed-licenses.txt
@@ -5,4 +5,9 @@ MIT
 EPL-2.0
 BSD-3-Clause
 EPL-1.0
+CDDL-1.1
+CC0-1.0
 Bouncy Castle Licence
+Eclipse Distribution License - Version 1.0
+# In the entry below we interpret it as CDDL-1.0
+(CDDL-1.0 OR GPL-2.0-with-classpath-exception)

--- a/scripts/license-check.py
+++ b/scripts/license-check.py
@@ -25,7 +25,6 @@ def discover_licenses(sbom):
     found_licenses = set()
     for item in sbom['components']:
         name, version, licenses = item['name'], item['version'], item['licenses']
-        # logging.debug(f'Processing {name}')
         if not item['licenses']:
             logging.warning(f'{name} {version}: Unspecified license!')
 

--- a/scripts/license-check.py
+++ b/scripts/license-check.py
@@ -8,6 +8,14 @@ import sys
 import argparse
 import pathlib
 
+# This is a set of special licenses that we treat in a unique way. They are not, and will not be featured in the SPDX,
+# because they are just an alias for another license (see referenced discussions for context). Therefore, we explicitly
+# give their names here (since they don't have IDs).
+SPECIAL_LICENSES = {
+    'Bouncy Castle Licence',  # https://github.com/spdx/license-list-XML/issues/910, MIT
+    'Eclipse Distribution License - Version 1.0',  # https://github.com/spdx/license-list-XML/issues/1683, BSD-3-clause
+}
+
 
 def discover_licenses(sbom):
     """Return a set of licenses featured in a given SBOM
@@ -17,14 +25,26 @@ def discover_licenses(sbom):
     found_licenses = set()
     for item in sbom['components']:
         name, version, licenses = item['name'], item['version'], item['licenses']
+        # logging.debug(f'Processing {name}')
         if not item['licenses']:
             logging.warning(f'{name} {version}: Unspecified license!')
 
         for entry in licenses:
-            # special treatment for bouncy castle
-            # https://github.com/spdx/license-list-XML/issues/910
-            if 'id' not in entry['license'] and entry['license']['name'] == 'Bouncy Castle Licence':
-                found_licenses.add('Bouncy Castle Licence')
+            if 'expression' in entry:
+                # Special case for clever licenses that are given as boolean expressions, e.g.
+                # "(CDDL-1.0 OR GPL-2.0-with-classpath-exception)". If this happens, we add the entire expression
+                # to the list without trying to parse it (because the notation can be complex). The entire expression
+                # must be added to the list of allowed licenses after a human checks it and ensures all is well.
+                # Yes, there will be different strings that have the same meaning (e.g. "X or Y", "Y or X") and they
+                # will have to be treated as different cases - that's fine. A human will have to think about it very
+                # well before updating allowed-licenses.txt.
+                found_licenses.add(entry['expression'])
+
+            elif 'id' not in entry['license'] and entry['license']['name'] in SPECIAL_LICENSES:
+                # Some licenses do not have an SPDX ID, this occurs when these licenses are nothing but renamed copies
+                # of some other license. In this case we extract the license name.
+                found_licenses.add(entry['license']['name'])
+
             else:
                 found_licenses.add(entry['license']['id'])
     return found_licenses
@@ -46,7 +66,10 @@ def generate_license_report(sbom):
             try:
                 license_id = entry['license']['id']
             except KeyError:
-                license_id = entry['license']['name']
+                try:
+                    license_id = entry['license']['name']
+                except KeyError:
+                    license_id = entry['expression']
             entries.append((name, version, license_id))
     return entries
 
@@ -80,8 +103,13 @@ def check_license_compliance(sbom, allowed):
             try:
                 license_id = license['license']['id']
             except KeyError:
-                license_id = license['license']['name']
-            if license_id not in allowed:
+                try:
+                    license_id = license['license']['name']
+                except KeyError:
+                    license_id = license['expression']
+            if license_id in allowed:
+                break
+            else:
                 errors.append((name, version, f'`{license_id}` not allowed'))
 
     if not errors:


### PR DESCRIPTION
Modify license parser for SBOM files:

The license parser now also supports more complex licenses specified as regular expressions or by a list of license alternatives.