### PR TITLE
feat: add logging while accessing configuration data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,10 @@ feat: implement configurable recipient
 
 fix: extension processing in CMP client
 
-### 4.1.0 (Dec 14 2024)
+### 4.1.0 (Dec 14 2023)
 
 feat: revocation checking via inventory interface
+
+### 4.1.2 (Feb 28 2024)
+
+feat: add logging while accessing configuration data

--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ between CMP RA component, downstream interface, and upstream interface:
   which supports dynamic changes.
     * Where appropriate, they may depend on a certificate profile
       optionally given in CMP request headers.
+* If accessing the configuration interface shall be logged, the SLF4J-Logger of
+  com.siemens.pki.cmpracomponent.util.ConfigLogger must be set to DEBUG, e.g.
+  start with 
+  -Dorg.slf4j.simpleLogger.log.com.siemens.pki.cmpracomponent.util.ConfigLogger=debug 
 
 
 ## Interfaces to inventory for certification request validation

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<groupId>com.siemens.pki</groupId>
 	<artifactId>CmpRaComponent</artifactId>
 	<packaging>jar</packaging>
-	<version>4.1.1</version>
+	<version>4.1.2</version>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<parent.basedir>.</parent.basedir>

--- a/src/main/java/com/siemens/pki/cmpclientcomponent/main/ClientRequestHandler.java
+++ b/src/main/java/com/siemens/pki/cmpclientcomponent/main/ClientRequestHandler.java
@@ -82,14 +82,18 @@ class ClientRequestHandler {
 
         public ValidatorAndProtector(NestedEndpointContext nestedEndpoint)
                 throws GeneralSecurityException, CmpProcessingException {
-            final VerificationContext inputVerification = ConfigLogger.logOptional(
-                    NESTED_INTERFACE_NAME,
-                    "NestedEndpointContext.getInputVerification()",
-                    () -> nestedEndpoint.getInputVerification());
             headerValidator = new MessageHeaderValidator(NESTED_INTERFACE_NAME);
             outputProtection = new MsgOutputProtector(nestedEndpoint, NESTED_INTERFACE_NAME);
-            this.inputVerification = inputVerification;
-            protectionValidator = new ProtectionValidator(NESTED_INTERFACE_NAME, inputVerification);
+            this.inputVerification = ConfigLogger.logOptional(
+                    NESTED_INTERFACE_NAME,
+                    "NestedEndpointContext.getInputVerification()",
+                    nestedEndpoint::getInputVerification);
+            protectionValidator = new ProtectionValidator(
+                    NESTED_INTERFACE_NAME,
+                    ConfigLogger.logOptional(
+                            NESTED_INTERFACE_NAME,
+                            "NestedEndpointContext.getInputVerification()",
+                            nestedEndpoint::getInputVerification));
             bodyValidator = new MessageBodyValidator(NESTED_INTERFACE_NAME, (x, y) -> false, null, certProfile);
         }
 
@@ -98,7 +102,7 @@ class ClientRequestHandler {
             this.inputVerification = ConfigLogger.logOptional(
                     INTERFACE_NAME,
                     "CmpMessageInterface.getInputVerification()",
-                    () -> upstreamConfiguration.getInputVerification());
+                    upstreamConfiguration::getInputVerification);
             headerValidator = new MessageHeaderValidator(INTERFACE_NAME);
             outputProtection = new MsgOutputProtector(upstreamConfiguration, INTERFACE_NAME, null);
             protectionValidator = new ProtectionValidator(INTERFACE_NAME, inputVerification);
@@ -166,7 +170,7 @@ class ClientRequestHandler {
                 ConfigLogger.logOptional(
                         INTERFACE_NAME,
                         "CmpMessageInterface.getNestedEndpointContext()",
-                        () -> upstreamConfiguration.getNestedEndpointContext()),
+                        upstreamConfiguration::getNestedEndpointContext),
                 ValidatorAndProtector::new);
     }
 

--- a/src/main/java/com/siemens/pki/cmpclientcomponent/main/ClientRequestHandler.java
+++ b/src/main/java/com/siemens/pki/cmpclientcomponent/main/ClientRequestHandler.java
@@ -35,6 +35,7 @@ import com.siemens.pki.cmpracomponent.msgvalidation.MessageBodyValidator;
 import com.siemens.pki.cmpracomponent.msgvalidation.MessageHeaderValidator;
 import com.siemens.pki.cmpracomponent.msgvalidation.ProtectionValidator;
 import com.siemens.pki.cmpracomponent.msgvalidation.ValidatorIF;
+import com.siemens.pki.cmpracomponent.util.ConfigLogger;
 import com.siemens.pki.cmpracomponent.util.FileTracer;
 import com.siemens.pki.cmpracomponent.util.MessageDumper;
 import java.security.GeneralSecurityException;
@@ -81,7 +82,10 @@ class ClientRequestHandler {
 
         public ValidatorAndProtector(NestedEndpointContext nestedEndpoint)
                 throws GeneralSecurityException, CmpProcessingException {
-            final VerificationContext inputVerification = nestedEndpoint.getInputVerification();
+            final VerificationContext inputVerification = ConfigLogger.logOptional(
+                    NESTED_INTERFACE_NAME,
+                    "NestedEndpointContext.getInputVerification()",
+                    () -> nestedEndpoint.getInputVerification());
             headerValidator = new MessageHeaderValidator(NESTED_INTERFACE_NAME);
             outputProtection = new MsgOutputProtector(nestedEndpoint, NESTED_INTERFACE_NAME);
             this.inputVerification = inputVerification;
@@ -91,7 +95,10 @@ class ClientRequestHandler {
 
         private ValidatorAndProtector(String certProfile, final CmpMessageInterface upstreamConfiguration)
                 throws GeneralSecurityException, CmpProcessingException {
-            this.inputVerification = upstreamConfiguration.getInputVerification();
+            this.inputVerification = ConfigLogger.logOptional(
+                    INTERFACE_NAME,
+                    "CmpMessageInterface.getInputVerification()",
+                    () -> upstreamConfiguration.getInputVerification());
             headerValidator = new MessageHeaderValidator(INTERFACE_NAME);
             outputProtection = new MsgOutputProtector(upstreamConfiguration, INTERFACE_NAME, null);
             protectionValidator = new ProtectionValidator(INTERFACE_NAME, inputVerification);
@@ -155,8 +162,12 @@ class ClientRequestHandler {
         this.upstreamExchange = upstreamExchange;
         this.certProfile = certProfile;
         validatorAndProtector = new ValidatorAndProtector(certProfile, upstreamConfiguration);
-        nestedValidatorAndProtector =
-                ifNotNull(upstreamConfiguration.getNestedEndpointContext(), ValidatorAndProtector::new);
+        nestedValidatorAndProtector = ifNotNull(
+                ConfigLogger.logOptional(
+                        INTERFACE_NAME,
+                        "CmpMessageInterface.getNestedEndpointContext()",
+                        () -> upstreamConfiguration.getNestedEndpointContext()),
+                ValidatorAndProtector::new);
     }
 
     PKIMessage buildFurtherRequest(final PKIMessage formerResponse, final PKIBody requestBody) throws Exception {

--- a/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/BaseCredentialService.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/BaseCredentialService.java
@@ -44,7 +44,7 @@ public class BaseCredentialService {
 
     protected List<X509Certificate> getCertChain() {
         return ConfigLogger.log(
-                interfaceName, "SignatureCredentialContext.getCertificateChain()", () -> config.getCertificateChain());
+                interfaceName, "SignatureCredentialContext.getCertificateChain()", config::getCertificateChain);
     }
 
     /**
@@ -60,8 +60,7 @@ public class BaseCredentialService {
      * @return private key related to end certificate
      */
     public PrivateKey getPrivateKey() {
-        return ConfigLogger.log(
-                interfaceName, "SignatureCredentialContext.getPrivateKey()", () -> config.getPrivateKey());
+        return ConfigLogger.log(interfaceName, "SignatureCredentialContext.getPrivateKey()", config::getPrivateKey);
     }
 
     protected AlgorithmIdentifier getSignatureAlgorithm() {
@@ -72,6 +71,6 @@ public class BaseCredentialService {
         return ConfigLogger.log(
                 interfaceName,
                 "SignatureCredentialContext.getSignatureAlgorithmName()",
-                () -> config.getSignatureAlgorithmName());
+                config::getSignatureAlgorithmName);
     }
 }

--- a/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/BaseCredentialService.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/BaseCredentialService.java
@@ -18,6 +18,7 @@
 package com.siemens.pki.cmpracomponent.cryptoservices;
 
 import com.siemens.pki.cmpracomponent.configuration.SignatureCredentialContext;
+import com.siemens.pki.cmpracomponent.util.ConfigLogger;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.util.List;
@@ -29,17 +30,21 @@ import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 public class BaseCredentialService {
 
     private final SignatureCredentialContext config;
+    final String interfaceName;
 
     /**
      * ctor
      * @param config related config
+     * @param interfaceName CMP interface name for logging
      */
-    public BaseCredentialService(final SignatureCredentialContext config) {
+    public BaseCredentialService(final SignatureCredentialContext config, String interfaceName) {
         this.config = config;
+        this.interfaceName = interfaceName;
     }
 
     protected List<X509Certificate> getCertChain() {
-        return config.getCertificateChain();
+        return ConfigLogger.log(
+                interfaceName, "SignatureCredentialContext.getCertificateChain()", () -> config.getCertificateChain());
     }
 
     /**
@@ -47,7 +52,7 @@ public class BaseCredentialService {
      * @return end certificate
      */
     public X509Certificate getEndCertificate() {
-        return config.getCertificateChain().get(0);
+        return getCertChain().get(0);
     }
 
     /**
@@ -55,7 +60,8 @@ public class BaseCredentialService {
      * @return private key related to end certificate
      */
     public PrivateKey getPrivateKey() {
-        return config.getPrivateKey();
+        return ConfigLogger.log(
+                interfaceName, "SignatureCredentialContext.getPrivateKey()", () -> config.getPrivateKey());
     }
 
     protected AlgorithmIdentifier getSignatureAlgorithm() {
@@ -63,6 +69,9 @@ public class BaseCredentialService {
     }
 
     protected String getSignatureAlgorithmName() {
-        return config.getSignatureAlgorithmName();
+        return ConfigLogger.log(
+                interfaceName,
+                "SignatureCredentialContext.getSignatureAlgorithmName()",
+                () -> config.getSignatureAlgorithmName());
     }
 }

--- a/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/CmsEncryptorBase.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/CmsEncryptorBase.java
@@ -18,11 +18,17 @@
 package com.siemens.pki.cmpracomponent.cryptoservices;
 
 import com.siemens.pki.cmpracomponent.configuration.CkgContext;
+import com.siemens.pki.cmpracomponent.util.ConfigLogger;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import org.bouncycastle.asn1.cms.EnvelopedData;
 import org.bouncycastle.asn1.cms.SignedData;
-import org.bouncycastle.cms.*;
+import org.bouncycastle.cms.CMSAlgorithm;
+import org.bouncycastle.cms.CMSEnvelopedData;
+import org.bouncycastle.cms.CMSEnvelopedDataGenerator;
+import org.bouncycastle.cms.CMSException;
+import org.bouncycastle.cms.CMSProcessableByteArray;
+import org.bouncycastle.cms.RecipientInfoGenerator;
 import org.bouncycastle.cms.jcajce.JceCMSContentEncryptorBuilder;
 
 /**
@@ -32,9 +38,15 @@ public class CmsEncryptorBase {
 
     private final CMSEnvelopedDataGenerator envGen = new CMSEnvelopedDataGenerator();
     private final CkgContext config;
+    private final String interfaceName;
 
-    protected CmsEncryptorBase(final CkgContext config) {
+    protected CmsEncryptorBase(final CkgContext config, String interfaceName) {
         this.config = config;
+        this.interfaceName = interfaceName;
+    }
+
+    protected void addRecipientInfoGenerator(final RecipientInfoGenerator recipientGenerator) {
+        envGen.addRecipientInfoGenerator(recipientGenerator);
     }
 
     /**
@@ -49,7 +61,10 @@ public class CmsEncryptorBase {
     public EnvelopedData encrypt(final byte[] msg) throws CMSException, NoSuchAlgorithmException {
         final CMSEnvelopedData cmsEnvData = envGen.generate(
                 new CMSProcessableByteArray(msg),
-                new JceCMSContentEncryptorBuilder(AlgorithmHelper.getKeyEncryptionOID(config.getContentEncryptionAlg()))
+                new JceCMSContentEncryptorBuilder(AlgorithmHelper.getKeyEncryptionOID(ConfigLogger.log(
+                                interfaceName,
+                                "CkgContext.getContentEncryptionAlg()",
+                                () -> config.getContentEncryptionAlg())))
                         .setProvider(CertUtility.getBouncyCastleProvider())
                         .build());
         return EnvelopedData.getInstance(cmsEnvData.toASN1Structure().getContent());
@@ -70,9 +85,5 @@ public class CmsEncryptorBase {
                         .setProvider(CertUtility.getBouncyCastleProvider())
                         .build());
         return EnvelopedData.getInstance(cmsEnvData.toASN1Structure().getContent());
-    }
-
-    protected void addRecipientInfoGenerator(final RecipientInfoGenerator recipientGenerator) {
-        envGen.addRecipientInfoGenerator(recipientGenerator);
     }
 }

--- a/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/CmsEncryptorBase.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/CmsEncryptorBase.java
@@ -64,7 +64,7 @@ public class CmsEncryptorBase {
                 new JceCMSContentEncryptorBuilder(AlgorithmHelper.getKeyEncryptionOID(ConfigLogger.log(
                                 interfaceName,
                                 "CkgContext.getContentEncryptionAlg()",
-                                () -> config.getContentEncryptionAlg())))
+                                config::getContentEncryptionAlg)))
                         .setProvider(CertUtility.getBouncyCastleProvider())
                         .build());
         return EnvelopedData.getInstance(cmsEnvData.toASN1Structure().getContent());

--- a/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/DataSignVerifier.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/DataSignVerifier.java
@@ -100,9 +100,10 @@ public class DataSignVerifier extends TrustCredentialAdapter {
     /**
      * ctor
      * @param config context used for verification
+     * @param interfaceName CMP interface name for logging
      */
-    public DataSignVerifier(final VerificationContext config) {
-        super(config);
+    public DataSignVerifier(final VerificationContext config, String interfaceName) {
+        super(config, interfaceName);
     }
 
     private boolean validate(final X509CertificateHolder cert, final List<X509Certificate> allCerts)

--- a/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/DataSigner.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/DataSigner.java
@@ -81,25 +81,28 @@ public class DataSigner {
      * ctor
      * @param privateKey private key used for signing
      * @param endCertificate certificate used for signing
+     * @param interfaceName CMP interface name for logging
      * @throws CertificateEncodingException in case of error
      * @throws OperatorCreationException in case of error
      * @throws IOException in case of error
      * @throws CMSException in case of error
      */
-    public DataSigner(final PrivateKey privateKey, final X509Certificate endCertificate)
+    public DataSigner(final PrivateKey privateKey, final X509Certificate endCertificate, String interfaceName)
             throws CertificateEncodingException, OperatorCreationException, IOException, CMSException {
-        this(new BaseCredentialService(new SignatureCredentialContext() {
+        this(new BaseCredentialService(
+                new SignatureCredentialContext() {
 
-            @Override
-            public List<X509Certificate> getCertificateChain() {
-                return Collections.singletonList(endCertificate);
-            }
+                    @Override
+                    public List<X509Certificate> getCertificateChain() {
+                        return Collections.singletonList(endCertificate);
+                    }
 
-            @Override
-            public PrivateKey getPrivateKey() {
-                return privateKey;
-            }
-        }));
+                    @Override
+                    public PrivateKey getPrivateKey() {
+                        return privateKey;
+                    }
+                },
+                interfaceName));
     }
 
     /**

--- a/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/KeyAgreementEncryptor.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/KeyAgreementEncryptor.java
@@ -20,6 +20,7 @@ package com.siemens.pki.cmpracomponent.cryptoservices;
 import com.siemens.pki.cmpracomponent.configuration.CkgContext;
 import com.siemens.pki.cmpracomponent.configuration.CkgKeyAgreementContext;
 import com.siemens.pki.cmpracomponent.msgvalidation.CmpEnrollmentException;
+import com.siemens.pki.cmpracomponent.util.ConfigLogger;
 import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
@@ -49,8 +50,9 @@ public class KeyAgreementEncryptor extends CmsEncryptorBase {
             final int initialRequestType,
             final String interfaceName)
             throws GeneralSecurityException, CmpEnrollmentException {
-        super(config);
-        final CkgKeyAgreementContext keyAgreementContext = config.getKeyAgreementContext();
+        super(config, interfaceName);
+        final CkgKeyAgreementContext keyAgreementContext = ConfigLogger.log(
+                interfaceName, "CkgContext.getKeyAgreementContext()", () -> config.getKeyAgreementContext());
         if (keyAgreementContext == null) {
             throw new CmpEnrollmentException(
                     initialRequestType,
@@ -59,12 +61,27 @@ public class KeyAgreementEncryptor extends CmsEncryptorBase {
                     "support for key management technique Key Agreement is not configured for central key generation");
         }
         final JceKeyAgreeRecipientInfoGenerator infGen = new JceKeyAgreeRecipientInfoGenerator(
-                AlgorithmHelper.getKeyAgreementOID(keyAgreementContext.getKeyAgreementAlg()),
-                keyAgreementContext.getOwnPrivateKey(),
-                keyAgreementContext.getOwnPublicKey(),
-                AlgorithmHelper.getKekOID(keyAgreementContext.getKeyEncryptionAlg()));
+                AlgorithmHelper.getKeyAgreementOID(ConfigLogger.log(
+                        interfaceName,
+                        "CkgKeyAgreementContext.getKeyAgreementAlg()",
+                        () -> keyAgreementContext.getKeyAgreementAlg())),
+                ConfigLogger.log(
+                        interfaceName,
+                        "CkgKeyAgreementContext.getOwnPrivateKey()",
+                        () -> keyAgreementContext.getOwnPrivateKey()),
+                ConfigLogger.log(
+                        interfaceName,
+                        "CkgKeyAgreementContext.getOwnPublicKey()",
+                        () -> keyAgreementContext.getOwnPublicKey()),
+                AlgorithmHelper.getKekOID(ConfigLogger.log(
+                        interfaceName,
+                        "CkgKeyAgreementContext.getKeyEncryptionAlg()",
+                        () -> keyAgreementContext.getKeyEncryptionAlg())));
 
-        infGen.addRecipient(keyAgreementContext.getRecipient(protectingCert));
+        infGen.addRecipient(ConfigLogger.log(
+                interfaceName,
+                "CkgKeyAgreementContext.getRecipient(X509Certificate)",
+                () -> keyAgreementContext.getRecipient(protectingCert)));
         addRecipientInfoGenerator(infGen.setProvider(CertUtility.getBouncyCastleProvider()));
     }
 }

--- a/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/KeyAgreementEncryptor.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/KeyAgreementEncryptor.java
@@ -51,8 +51,8 @@ public class KeyAgreementEncryptor extends CmsEncryptorBase {
             final String interfaceName)
             throws GeneralSecurityException, CmpEnrollmentException {
         super(config, interfaceName);
-        final CkgKeyAgreementContext keyAgreementContext = ConfigLogger.log(
-                interfaceName, "CkgContext.getKeyAgreementContext()", () -> config.getKeyAgreementContext());
+        final CkgKeyAgreementContext keyAgreementContext =
+                ConfigLogger.log(interfaceName, "CkgContext.getKeyAgreementContext()", config::getKeyAgreementContext);
         if (keyAgreementContext == null) {
             throw new CmpEnrollmentException(
                     initialRequestType,
@@ -64,19 +64,19 @@ public class KeyAgreementEncryptor extends CmsEncryptorBase {
                 AlgorithmHelper.getKeyAgreementOID(ConfigLogger.log(
                         interfaceName,
                         "CkgKeyAgreementContext.getKeyAgreementAlg()",
-                        () -> keyAgreementContext.getKeyAgreementAlg())),
+                        keyAgreementContext::getKeyAgreementAlg)),
                 ConfigLogger.log(
                         interfaceName,
                         "CkgKeyAgreementContext.getOwnPrivateKey()",
-                        () -> keyAgreementContext.getOwnPrivateKey()),
+                        keyAgreementContext::getOwnPrivateKey),
                 ConfigLogger.log(
                         interfaceName,
                         "CkgKeyAgreementContext.getOwnPublicKey()",
-                        () -> keyAgreementContext.getOwnPublicKey()),
+                        keyAgreementContext::getOwnPublicKey),
                 AlgorithmHelper.getKekOID(ConfigLogger.log(
                         interfaceName,
                         "CkgKeyAgreementContext.getKeyEncryptionAlg()",
-                        () -> keyAgreementContext.getKeyEncryptionAlg())));
+                        keyAgreementContext::getKeyEncryptionAlg)));
 
         infGen.addRecipient(ConfigLogger.log(
                 interfaceName,

--- a/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/KeyTransportEncryptor.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/KeyTransportEncryptor.java
@@ -20,6 +20,7 @@ package com.siemens.pki.cmpracomponent.cryptoservices;
 import com.siemens.pki.cmpracomponent.configuration.CkgContext;
 import com.siemens.pki.cmpracomponent.configuration.CkgKeyTransportContext;
 import com.siemens.pki.cmpracomponent.msgvalidation.CmpEnrollmentException;
+import com.siemens.pki.cmpracomponent.util.ConfigLogger;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.cert.X509Certificate;
@@ -49,8 +50,9 @@ public class KeyTransportEncryptor extends CmsEncryptorBase {
             final int initialRequestType,
             final String interfaceName)
             throws NoSuchAlgorithmException, CmpEnrollmentException {
-        super(config);
-        final CkgKeyTransportContext transportContext = config.getKeyTransportContext();
+        super(config, interfaceName);
+        final CkgKeyTransportContext transportContext = ConfigLogger.log(
+                interfaceName, "CkgContext.getKeyTransportContext()", () -> config.getKeyTransportContext());
         if (transportContext == null) {
             throw new CmpEnrollmentException(
                     initialRequestType,
@@ -59,7 +61,10 @@ public class KeyTransportEncryptor extends CmsEncryptorBase {
                     "support for key management technique Key Transport is not configured for central key generation");
         }
         final JcaX509ExtensionUtils jcaX509ExtensionUtils = new JcaX509ExtensionUtils();
-        final X509Certificate encryptionCert = transportContext.getRecipient(protectingCert);
+        final X509Certificate encryptionCert = ConfigLogger.log(
+                interfaceName,
+                "CkgKeyTransportContext.getRecipient(X509Certificate)",
+                () -> transportContext.getRecipient(protectingCert));
         final PublicKey publicKey = encryptionCert.getPublicKey();
         addRecipientInfoGenerator(new JceKeyTransRecipientInfoGenerator(
                         jcaX509ExtensionUtils

--- a/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/KeyTransportEncryptor.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/KeyTransportEncryptor.java
@@ -51,8 +51,8 @@ public class KeyTransportEncryptor extends CmsEncryptorBase {
             final String interfaceName)
             throws NoSuchAlgorithmException, CmpEnrollmentException {
         super(config, interfaceName);
-        final CkgKeyTransportContext transportContext = ConfigLogger.log(
-                interfaceName, "CkgContext.getKeyTransportContext()", () -> config.getKeyTransportContext());
+        final CkgKeyTransportContext transportContext =
+                ConfigLogger.log(interfaceName, "CkgContext.getKeyTransportContext()", config::getKeyTransportContext);
         if (transportContext == null) {
             throw new CmpEnrollmentException(
                     initialRequestType,

--- a/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/PasswordEncryptor.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/PasswordEncryptor.java
@@ -45,7 +45,7 @@ public class PasswordEncryptor extends CmsEncryptorBase {
             throws NoSuchAlgorithmException, CmpEnrollmentException {
         super(config, interfaceName);
         final CkgPasswordContext passwordContext =
-                ConfigLogger.log(interfaceName, "CkgContext.getPasswordContext()", () -> config.getPasswordContext());
+                ConfigLogger.log(interfaceName, "CkgContext.getPasswordContext()", config::getPasswordContext);
         if (passwordContext == null) {
             throw new CmpEnrollmentException(
                     initialRequestType,
@@ -56,26 +56,26 @@ public class PasswordEncryptor extends CmsEncryptorBase {
         final SharedSecretCredentialContext encryptionCredentials = ConfigLogger.log(
                 interfaceName,
                 "CkgPasswordContext.getEncryptionCredentials()",
-                () -> passwordContext.getEncryptionCredentials());
+                passwordContext::getEncryptionCredentials);
         addRecipientInfoGenerator(new JcePasswordRecipientInfoGenerator(
                         AlgorithmHelper.getKeyEncryptionOID(ConfigLogger.log(
-                                interfaceName, "CkgPasswordContext.getKekAlg()", () -> passwordContext.getKekAlg())),
+                                interfaceName, "CkgPasswordContext.getKekAlg()", passwordContext::getKekAlg)),
                         AlgorithmHelper.convertSharedSecretToPassword(ConfigLogger.log(
                                 interfaceName,
                                 "SharedSecretCredentialContext.getSharedSecret()",
-                                () -> encryptionCredentials.getSharedSecret())))
+                                encryptionCredentials::getSharedSecret)))
                 .setProvider(CertUtility.getBouncyCastleProvider())
                 .setPasswordConversionScheme(PasswordRecipient.PKCS5_SCHEME2_UTF8)
                 .setPRF(AlgorithmHelper.getPrf(ConfigLogger.log(
-                        interfaceName, "SharedSecretCredentialContext.getPrf()", () -> encryptionCredentials.getPrf())))
+                        interfaceName, "SharedSecretCredentialContext.getPrf()", encryptionCredentials::getPrf)))
                 .setSaltAndIterationCount(
                         ConfigLogger.log(
                                 interfaceName,
                                 "SharedSecretCredentialContext.getSalt()",
-                                () -> encryptionCredentials.getSalt()),
+                                encryptionCredentials::getSalt),
                         ConfigLogger.log(
                                 interfaceName,
                                 "SharedSecretCredentialContext.getIterationCount()",
-                                () -> encryptionCredentials.getIterationCount())));
+                                encryptionCredentials::getIterationCount)));
     }
 }

--- a/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/PasswordEncryptor.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/PasswordEncryptor.java
@@ -21,6 +21,7 @@ import com.siemens.pki.cmpracomponent.configuration.CkgContext;
 import com.siemens.pki.cmpracomponent.configuration.CkgPasswordContext;
 import com.siemens.pki.cmpracomponent.configuration.SharedSecretCredentialContext;
 import com.siemens.pki.cmpracomponent.msgvalidation.CmpEnrollmentException;
+import com.siemens.pki.cmpracomponent.util.ConfigLogger;
 import java.security.NoSuchAlgorithmException;
 import org.bouncycastle.asn1.cmp.PKIFailureInfo;
 import org.bouncycastle.cms.PasswordRecipient;
@@ -42,8 +43,9 @@ public class PasswordEncryptor extends CmsEncryptorBase {
      */
     public PasswordEncryptor(final CkgContext config, final int initialRequestType, final String interfaceName)
             throws NoSuchAlgorithmException, CmpEnrollmentException {
-        super(config);
-        final CkgPasswordContext passwordContext = config.getPasswordContext();
+        super(config, interfaceName);
+        final CkgPasswordContext passwordContext =
+                ConfigLogger.log(interfaceName, "CkgContext.getPasswordContext()", () -> config.getPasswordContext());
         if (passwordContext == null) {
             throw new CmpEnrollmentException(
                     initialRequestType,
@@ -51,13 +53,29 @@ public class PasswordEncryptor extends CmsEncryptorBase {
                     PKIFailureInfo.notAuthorized,
                     "support for key management technique Password-Based is not configured for central key generation");
         }
-        final SharedSecretCredentialContext encryptionCredentials = passwordContext.getEncryptionCredentials();
+        final SharedSecretCredentialContext encryptionCredentials = ConfigLogger.log(
+                interfaceName,
+                "CkgPasswordContext.getEncryptionCredentials()",
+                () -> passwordContext.getEncryptionCredentials());
         addRecipientInfoGenerator(new JcePasswordRecipientInfoGenerator(
-                        AlgorithmHelper.getKeyEncryptionOID(passwordContext.getKekAlg()),
-                        AlgorithmHelper.convertSharedSecretToPassword(encryptionCredentials.getSharedSecret()))
+                        AlgorithmHelper.getKeyEncryptionOID(ConfigLogger.log(
+                                interfaceName, "CkgPasswordContext.getKekAlg()", () -> passwordContext.getKekAlg())),
+                        AlgorithmHelper.convertSharedSecretToPassword(ConfigLogger.log(
+                                interfaceName,
+                                "SharedSecretCredentialContext.getSharedSecret()",
+                                () -> encryptionCredentials.getSharedSecret())))
                 .setProvider(CertUtility.getBouncyCastleProvider())
                 .setPasswordConversionScheme(PasswordRecipient.PKCS5_SCHEME2_UTF8)
-                .setPRF(AlgorithmHelper.getPrf(encryptionCredentials.getPrf()))
-                .setSaltAndIterationCount(encryptionCredentials.getSalt(), encryptionCredentials.getIterationCount()));
+                .setPRF(AlgorithmHelper.getPrf(ConfigLogger.log(
+                        interfaceName, "SharedSecretCredentialContext.getPrf()", () -> encryptionCredentials.getPrf())))
+                .setSaltAndIterationCount(
+                        ConfigLogger.log(
+                                interfaceName,
+                                "SharedSecretCredentialContext.getSalt()",
+                                () -> encryptionCredentials.getSalt()),
+                        ConfigLogger.log(
+                                interfaceName,
+                                "SharedSecretCredentialContext.getIterationCount()",
+                                () -> encryptionCredentials.getIterationCount())));
     }
 }

--- a/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/TrustCredentialAdapter.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/TrustCredentialAdapter.java
@@ -18,6 +18,7 @@
 package com.siemens.pki.cmpracomponent.cryptoservices;
 
 import com.siemens.pki.cmpracomponent.configuration.VerificationContext;
+import com.siemens.pki.cmpracomponent.util.ConfigLogger;
 import java.net.URI;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
@@ -62,12 +63,23 @@ public class TrustCredentialAdapter {
 
     private final VerificationContext config;
 
+    private final String interfaceName;
+
     /**
      * ctor
      * @param config specific configuration
+     * @param interfaceName CMP interface name for logging
      */
-    public TrustCredentialAdapter(final VerificationContext config) {
+    public TrustCredentialAdapter(final VerificationContext config, String interfaceName) {
         this.config = config;
+        this.interfaceName = interfaceName;
+    }
+
+    public boolean isIntermediateCertAcceptable(X509Certificate cert) {
+        return ConfigLogger.log(
+                interfaceName,
+                "VerificationContext.isIntermediateCertAcceptable(X509Certificate)",
+                () -> config.isIntermediateCertAcceptable(cert));
     }
 
     /**
@@ -87,7 +99,8 @@ public class TrustCredentialAdapter {
     public synchronized List<? extends X509Certificate> validateCertAgainstTrust(
             final X509Certificate cert, final List<X509Certificate> additionalIntermediateCerts)
             throws NoSuchProviderException {
-        final Collection<X509Certificate> trustedCertificates = config.getTrustedCertificates();
+        final Collection<X509Certificate> trustedCertificates = ConfigLogger.logOptional(
+                interfaceName, "VerificationContext.getTrustedCertificates()", () -> config.getTrustedCertificates());
         if (trustedCertificates == null) {
             return null;
         }
@@ -107,7 +120,10 @@ public class TrustCredentialAdapter {
         try {
             final boolean[] leafKeyUsage = cert.getKeyUsage();
             if (leafKeyUsage != null && !leafKeyUsage[0] // digitalSignature
-                    || !config.isLeafCertAcceptable(cert)) {
+                    || !ConfigLogger.log(
+                            interfaceName,
+                            "VerificationContext.isLeafCertAcceptable(X509Certificate)",
+                            () -> config.isLeafCertAcceptable(cert))) {
                 return null;
             }
             // initial state
@@ -123,7 +139,7 @@ public class TrustCredentialAdapter {
 
             final PKIXBuilderParameters params = new PKIXBuilderParameters(trust, targetConstraints);
 
-            if (config.isAIAsEnabled()) {
+            if (ConfigLogger.log(interfaceName, "VerificationContext.isAIAsEnabled()", () -> config.isAIAsEnabled())) {
                 revocationEnabled = true;
                 java.security.Security.setProperty(OCSP_ENABLE_PROP, "true");
                 System.setProperty("com.sun.security.enableAIAcaIssuers", "true");
@@ -131,7 +147,7 @@ public class TrustCredentialAdapter {
                 System.setProperty("com.sun.security.enableAIAcaIssuers", FALSE_STRING);
             }
 
-            if (config.isCDPsEnabled()) {
+            if (ConfigLogger.log(interfaceName, "VerificationContext.isCDPsEnabled()", () -> config.isCDPsEnabled())) {
                 revocationEnabled = true;
                 System.setProperty("com.sun.security.enableCRLDP", "true");
             } else {
@@ -142,12 +158,13 @@ public class TrustCredentialAdapter {
 
             if (additionalIntermediateCerts != null) {
                 additionalIntermediateCerts.stream()
-                        .filter(config::isIntermediateCertAcceptable)
+                        .filter(this::isIntermediateCertAcceptable)
                         .filter(CertUtility::isIntermediateCertificate)
                         .forEach(lstCertCrlStores::add);
             }
 
-            final Collection<X509Certificate> additionalCertsFromConfig = config.getAdditionalCerts();
+            final Collection<X509Certificate> additionalCertsFromConfig = ConfigLogger.logOptional(
+                    interfaceName, "VerificationContext.getAdditionalCerts()", () -> config.getAdditionalCerts());
             if (additionalCertsFromConfig != null) {
                 lstCertCrlStores.addAll(additionalCertsFromConfig);
             }
@@ -156,7 +173,8 @@ public class TrustCredentialAdapter {
                     CertStore.getInstance("Collection", new CollectionCertStoreParameters(lstCertCrlStores), PROVIDER);
             params.addCertStore(certStore);
 
-            final Collection<X509CRL> crlsFromConfig = config.getCRLs();
+            final Collection<X509CRL> crlsFromConfig =
+                    ConfigLogger.logOptional(interfaceName, "VerificationContext.getCRLs()", () -> config.getCRLs());
             if (crlsFromConfig != null) {
                 if (!crlsFromConfig.isEmpty()) {
                     revocationEnabled = true;
@@ -170,12 +188,16 @@ public class TrustCredentialAdapter {
 
             final PKIXRevocationChecker revChecker = (PKIXRevocationChecker) cpb.getRevocationChecker();
 
-            final EnumSet<Option> pkixRevocationCheckerOptions = config.getPKIXRevocationCheckerOptions();
+            final EnumSet<Option> pkixRevocationCheckerOptions = ConfigLogger.logOptional(
+                    interfaceName,
+                    "VerificationContext.getPKIXRevocationCheckerOptions()",
+                    () -> config.getPKIXRevocationCheckerOptions());
             if (pkixRevocationCheckerOptions != null) {
                 revChecker.setOptions(pkixRevocationCheckerOptions);
             }
 
-            final URI ocspResponder = config.getOCSPResponder();
+            final URI ocspResponder = ConfigLogger.logOptional(
+                    interfaceName, "VerificationContext.getOCSPResponder()", () -> config.getOCSPResponder());
             if (ocspResponder != null) {
                 revocationEnabled = true;
                 java.security.Security.setProperty(OCSP_ENABLE_PROP, "true");

--- a/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/TrustCredentialAdapter.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/TrustCredentialAdapter.java
@@ -100,7 +100,7 @@ public class TrustCredentialAdapter {
             final X509Certificate cert, final List<X509Certificate> additionalIntermediateCerts)
             throws NoSuchProviderException {
         final Collection<X509Certificate> trustedCertificates = ConfigLogger.logOptional(
-                interfaceName, "VerificationContext.getTrustedCertificates()", () -> config.getTrustedCertificates());
+                interfaceName, "VerificationContext.getTrustedCertificates()", config::getTrustedCertificates);
         if (trustedCertificates == null) {
             return null;
         }
@@ -139,7 +139,7 @@ public class TrustCredentialAdapter {
 
             final PKIXBuilderParameters params = new PKIXBuilderParameters(trust, targetConstraints);
 
-            if (ConfigLogger.log(interfaceName, "VerificationContext.isAIAsEnabled()", () -> config.isAIAsEnabled())) {
+            if (ConfigLogger.log(interfaceName, "VerificationContext.isAIAsEnabled()", config::isAIAsEnabled)) {
                 revocationEnabled = true;
                 java.security.Security.setProperty(OCSP_ENABLE_PROP, "true");
                 System.setProperty("com.sun.security.enableAIAcaIssuers", "true");
@@ -147,7 +147,7 @@ public class TrustCredentialAdapter {
                 System.setProperty("com.sun.security.enableAIAcaIssuers", FALSE_STRING);
             }
 
-            if (ConfigLogger.log(interfaceName, "VerificationContext.isCDPsEnabled()", () -> config.isCDPsEnabled())) {
+            if (ConfigLogger.log(interfaceName, "VerificationContext.isCDPsEnabled()", config::isCDPsEnabled)) {
                 revocationEnabled = true;
                 System.setProperty("com.sun.security.enableCRLDP", "true");
             } else {
@@ -164,7 +164,7 @@ public class TrustCredentialAdapter {
             }
 
             final Collection<X509Certificate> additionalCertsFromConfig = ConfigLogger.logOptional(
-                    interfaceName, "VerificationContext.getAdditionalCerts()", () -> config.getAdditionalCerts());
+                    interfaceName, "VerificationContext.getAdditionalCerts()", config::getAdditionalCerts);
             if (additionalCertsFromConfig != null) {
                 lstCertCrlStores.addAll(additionalCertsFromConfig);
             }
@@ -174,7 +174,7 @@ public class TrustCredentialAdapter {
             params.addCertStore(certStore);
 
             final Collection<X509CRL> crlsFromConfig =
-                    ConfigLogger.logOptional(interfaceName, "VerificationContext.getCRLs()", () -> config.getCRLs());
+                    ConfigLogger.logOptional(interfaceName, "VerificationContext.getCRLs()", config::getCRLs);
             if (crlsFromConfig != null) {
                 if (!crlsFromConfig.isEmpty()) {
                     revocationEnabled = true;
@@ -191,13 +191,13 @@ public class TrustCredentialAdapter {
             final EnumSet<Option> pkixRevocationCheckerOptions = ConfigLogger.logOptional(
                     interfaceName,
                     "VerificationContext.getPKIXRevocationCheckerOptions()",
-                    () -> config.getPKIXRevocationCheckerOptions());
+                    config::getPKIXRevocationCheckerOptions);
             if (pkixRevocationCheckerOptions != null) {
                 revChecker.setOptions(pkixRevocationCheckerOptions);
             }
 
             final URI ocspResponder = ConfigLogger.logOptional(
-                    interfaceName, "VerificationContext.getOCSPResponder()", () -> config.getOCSPResponder());
+                    interfaceName, "VerificationContext.getOCSPResponder()", config::getOCSPResponder);
             if (ocspResponder != null) {
                 revocationEnabled = true;
                 java.security.Security.setProperty(OCSP_ENABLE_PROP, "true");

--- a/src/main/java/com/siemens/pki/cmpracomponent/msggeneration/MsgOutputProtector.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msggeneration/MsgOutputProtector.java
@@ -80,15 +80,14 @@ public class MsgOutputProtector {
         suppressRedundantExtraCerts = ConfigLogger.log(
                 interfaceName,
                 "CmpMessageInterface.getSuppressRedundantExtraCerts()",
-                () -> config.getSuppressRedundantExtraCerts());
-        reprotectMode = ConfigLogger.log(
-                interfaceName, "CmpMessageInterface.getReprotectMode()", () -> config.getReprotectMode());
+                config::getSuppressRedundantExtraCerts);
+        reprotectMode =
+                ConfigLogger.log(interfaceName, "CmpMessageInterface.getReprotectMode()", config::getReprotectMode);
         recipient = ifNotNull(
-                ConfigLogger.logOptional(
-                        interfaceName, "CmpMessageInterface.getRecipient()", () -> config.getRecipient()),
+                ConfigLogger.logOptional(interfaceName, "CmpMessageInterface.getRecipient()", config::getRecipient),
                 rec -> new GeneralName(new X500Name(rec)));
         final CredentialContext outputCredentials = ConfigLogger.logOptional(
-                interfaceName, "CmpMessageInterface.getOutputCredentials()", () -> config.getOutputCredentials());
+                interfaceName, "CmpMessageInterface.getOutputCredentials()", config::getOutputCredentials);
         if (reprotectMode == ReprotectMode.reprotect && outputCredentials == null) {
             throw new CmpProcessingException(
                     interfaceName,
@@ -111,14 +110,11 @@ public class MsgOutputProtector {
         suppressRedundantExtraCerts = false;
         reprotectMode = ReprotectMode.reprotect;
         recipient = ifNotNull(
-                ConfigLogger.logOptional(
-                        interfaceName, "NestedEndpointContext.getRecipient()", () -> config.getRecipient()),
+                ConfigLogger.logOptional(interfaceName, "NestedEndpointContext.getRecipient()", config::getRecipient),
                 rec -> new GeneralName(new X500Name(rec)));
         protector = ProtectionProviderFactory.createProtectionProvider(
                 ConfigLogger.logOptional(
-                        interfaceName,
-                        "NestedEndpointContext.getOutputCredentials()",
-                        () -> config.getOutputCredentials()),
+                        interfaceName, "NestedEndpointContext.getOutputCredentials()", config::getOutputCredentials),
                 interfaceName);
     }
 

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/CmpRaUpstream.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/CmpRaUpstream.java
@@ -167,7 +167,7 @@ class CmpRaUpstream implements RaUpstream {
             final NestedEndpointContext nestedEndpointContext = ConfigLogger.logOptional(
                     INTERFACE_NAME,
                     "CmpMessageInterface.getNestedEndpointContext()",
-                    () -> upstreamConfiguration.getNestedEndpointContext());
+                    upstreamConfiguration::getNestedEndpointContext);
             if (nestedEndpointContext != null) {
                 final MsgOutputProtector nestedProtector =
                         new MsgOutputProtector(nestedEndpointContext, "NESTED CMP upstream");

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/RaDownstream.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/RaDownstream.java
@@ -46,6 +46,7 @@ import com.siemens.pki.cmpracomponent.msgvalidation.ProtectionValidator;
 import com.siemens.pki.cmpracomponent.persistency.PersistencyContext;
 import com.siemens.pki.cmpracomponent.persistency.PersistencyContextManager;
 import com.siemens.pki.cmpracomponent.protection.SignatureBasedProtection;
+import com.siemens.pki.cmpracomponent.util.ConfigLogger;
 import com.siemens.pki.cmpracomponent.util.MessageDumper;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -177,8 +178,12 @@ class RaDownstream {
     private MsgOutputProtector getOutputProtector(final PersistencyContext persistencyContext, final int bodyType)
             throws Exception {
         return new MsgOutputProtector(
-                config.getDownstreamConfiguration(
-                        ifNotNull(persistencyContext, PersistencyContext::getCertProfile), bodyType),
+                ConfigLogger.log(
+                        INTERFACE_NAME,
+                        "Configuration.getDownstreamConfiguration",
+                        config::getDownstreamConfiguration,
+                        ifNotNull(persistencyContext, PersistencyContext::getCertProfile),
+                        bodyType),
                 INTERFACE_NAME,
                 persistencyContext);
     }
@@ -203,7 +208,12 @@ class RaDownstream {
         CertTemplate certTemplate = certRequest.getCertTemplate();
 
         // check request against inventory
-        final InventoryInterface inventory = config.getInventory(persistencyContext.getCertProfile(), requestBodyType);
+        final InventoryInterface inventory = ConfigLogger.logOptional(
+                INTERFACE_NAME,
+                "Configuration.getInventory",
+                config::getInventory,
+                persistencyContext.getCertProfile(),
+                requestBodyType);
         if (inventory != null) {
             String requesterDn = null;
             final CMPCertificate[] extraCertsFromDownstreamRequest = incomingCertificateRequest.getExtraCerts();
@@ -219,21 +229,37 @@ class RaDownstream {
                     requesterDn = sender.toString();
                 }
             }
-            final CheckAndModifyResult checkResult = inventory.checkAndModifyCertRequest(
-                    persistencyContext.getTransactionId(),
-                    requesterDn,
-                    certTemplate.getEncoded(),
-                    ifNotNull(certTemplate.getSubject(), X500Name::toString),
-                    incomingCertificateRequest.getEncoded());
+            final String requesterDn_final = requesterDn;
+            final CertTemplate certTemplate_final = certTemplate;
+            final CheckAndModifyResult checkResult = ConfigLogger.logOptional(
+                    INTERFACE_NAME,
+                    "InventoryInterface.checkAndModifyCertRequest(byte[], String, byte[], String, byte[])",
+                    () -> {
+                        try {
+                            return inventory.checkAndModifyCertRequest(
+                                    persistencyContext.getTransactionId(),
+                                    requesterDn_final,
+                                    certTemplate_final.getEncoded(),
+                                    ifNotNull(certTemplate_final.getSubject(), X500Name::toString),
+                                    incomingCertificateRequest.getEncoded());
+                        } catch (IOException | RuntimeException e) {
+                            return null;
+                        }
+                    });
 
-            if (checkResult == null || !checkResult.isGranted()) {
+            if (checkResult == null
+                    || !ConfigLogger.log(
+                            INTERFACE_NAME, "CheckAndModifyResult.isGranted()", () -> checkResult.isGranted())) {
                 throw new CmpEnrollmentException(
                         requestBodyType,
                         INTERFACE_NAME,
                         PKIFailureInfo.badCertTemplate,
                         "request refused by external inventory");
             }
-            final byte[] updatedCertTemplate = checkResult.getUpdatedCertTemplate();
+            final byte[] updatedCertTemplate = ConfigLogger.logOptional(
+                    INTERFACE_NAME,
+                    "CheckAndModifyResult.getUpdatedCertTemplate()",
+                    () -> checkResult.getUpdatedCertTemplate());
             if (updatedCertTemplate != null) {
                 certTemplate = CertTemplate.getInstance(updatedCertTemplate);
                 certRequest = new CertRequest(0, certTemplate, certRequest.getControls());
@@ -308,12 +334,22 @@ class RaDownstream {
                             PKIBody.TYPE_CERT_REQ,
                             certTemplateWithPublicKey,
                             controlsInRequest,
-                            config.getForceRaVerifyOnUpstream(persistencyContext.getCertProfile(), requestBodyType)
+                            ConfigLogger.log(
+                                            INTERFACE_NAME,
+                                            "Configuration.getForceRaVerifyOnUpstream",
+                                            config::getForceRaVerifyOnUpstream,
+                                            persistencyContext.getCertProfile(),
+                                            requestBodyType)
                                     ? null
                                     : privateKey));
         }
         final ProofOfPossession popo = certReqMsg.getPop();
-        if (config.getForceRaVerifyOnUpstream(persistencyContext.getCertProfile(), requestBodyType)
+        if (ConfigLogger.log(
+                        INTERFACE_NAME,
+                        "Configuration.getForceRaVerifyOnUpstream",
+                        config::getForceRaVerifyOnUpstream,
+                        persistencyContext.getCertProfile(),
+                        requestBodyType)
                 || popo == null
                 || popo.getType() == ProofOfPossession.TYPE_RA_VERIFIED) {
             // popo invalid or raVerified, regenerate body
@@ -359,24 +395,34 @@ class RaDownstream {
             try {
                 final int inBodyType = in.getBody().getType();
                 if (inBodyType == PKIBody.TYPE_NESTED) {
-                    final CmpMessageInterface downstreamConfiguration =
-                            config.getDownstreamConfiguration(null, inBodyType);
-                    final NestedEndpointContext nestedEndpointContext =
-                            downstreamConfiguration.getNestedEndpointContext();
+                    final CmpMessageInterface downstreamConfiguration = ConfigLogger.log(
+                            INTERFACE_NAME,
+                            "Configuration.getDownstreamConfiguration",
+                            config::getDownstreamConfiguration,
+                            null,
+                            inBodyType);
+                    final NestedEndpointContext nestedEndpointContext = ConfigLogger.logOptional(
+                            INTERFACE_NAME,
+                            "CmpMessageInterface.getNestedEndpointContext()",
+                            () -> downstreamConfiguration.getNestedEndpointContext());
                     if (nestedEndpointContext != null) {
-                        final String NESTED_STRING = "nested ";
+                        final String NESTED_INTERFACE_NAME = "nested " + INTERFACE_NAME;
                         final MessageHeaderValidator headerValidator =
-                                new MessageHeaderValidator(NESTED_STRING + INTERFACE_NAME);
+                                new MessageHeaderValidator(NESTED_INTERFACE_NAME);
                         headerValidator.validate(in);
                         final ProtectionValidator protectionValidator = new ProtectionValidator(
-                                NESTED_STRING + INTERFACE_NAME, nestedEndpointContext.getInputVerification());
+                                NESTED_INTERFACE_NAME,
+                                ConfigLogger.logOptional(
+                                        NESTED_INTERFACE_NAME,
+                                        "NestedEndpointContext.getInputVerification()",
+                                        () -> nestedEndpointContext.getInputVerification()));
                         protectionValidator.validate(in);
                         final PKIMessage[] embeddedMessages = PKIMessages.getInstance(
                                         in.getBody().getContent())
                                 .toPKIMessageArray();
                         if (embeddedMessages == null || embeddedMessages.length == 0) {
                             throw new CmpProcessingException(
-                                    NESTED_STRING + INTERFACE_NAME,
+                                    NESTED_INTERFACE_NAME,
                                     PKIFailureInfo.badMessageCheck,
                                     "no embedded messages inside NESTED message");
                         }
@@ -438,8 +484,12 @@ class RaDownstream {
                         .generateAndProtectResponseTo(in, errorBody);
             } finally {
                 if (persistencyContext != null) {
-                    int offset = config.getDownstreamTimeout(
-                            ifNotNull(persistencyContext, PersistencyContext::getCertProfile), responseBodyType);
+                    int offset = ConfigLogger.log(
+                            INTERFACE_NAME,
+                            "Configuration.getDownstreamTimeout",
+                            config::getDownstreamTimeout,
+                            ifNotNull(persistencyContext, PersistencyContext::getCertProfile),
+                            responseBodyType);
                     if (offset == 0) {
                         offset = Integer.MAX_VALUE / 2;
                     }
@@ -467,8 +517,12 @@ class RaDownstream {
             }
 
             // check request against inventory
-            final InventoryInterface inventory =
-                    config.getInventory(persistencyContext.getCertProfile(), body.getType());
+            final InventoryInterface inventory = ConfigLogger.logOptional(
+                    INTERFACE_NAME,
+                    "Configuration.getInventory",
+                    config::getInventory,
+                    persistencyContext.getCertProfile(),
+                    body.getType());
             if (inventory != null) {
                 String requesterDn = null;
                 final CMPCertificate[] extraCertsFromUpstreamResponse = incomingP10Request.getExtraCerts();
@@ -483,18 +537,30 @@ class RaDownstream {
                         requesterDn = sender.toString();
                     }
                 }
-                if (!inventory.checkP10CertRequest(
-                        persistencyContext.getTransactionId(),
-                        requesterDn,
-                        p10Request.getEncoded(),
-                        p10Request.getSubject().toString(),
-                        incomingP10Request.getEncoded())) {
+                final PKCS10CertificationRequest p10Request_final = p10Request;
+                final PKIMessage incomingP10Request_final = incomingP10Request;
+                final String requesterDn_final = requesterDn;
+                if (!ConfigLogger.log(
+                        INTERFACE_NAME,
+                        "InventoryInterface.checkP10CertRequest(byte[], String, byte[], String, byte[])",
+                        () -> {
+                            try {
+                                return inventory.checkP10CertRequest(
+                                        persistencyContext.getTransactionId(),
+                                        requesterDn_final,
+                                        p10Request_final.getEncoded(),
+                                        p10Request_final.getSubject().toString(),
+                                        incomingP10Request_final.getEncoded());
+                            } catch (final IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        })) {
                     throw new CmpValidationException(
                             INTERFACE_NAME, PKIFailureInfo.badCertTemplate, "request refused by external inventory");
                 }
             }
             return incomingP10Request;
-        } catch (final IOException | OperatorCreationException | PKCSException e) {
+        } catch (final OperatorCreationException | PKCSException e) {
             throw new CmpProcessingException(INTERFACE_NAME, PKIFailureInfo.badMessageCheck, e);
         }
     }
@@ -504,25 +570,36 @@ class RaDownstream {
         final PKIBody body = incomingRequest.getBody();
         final int requestType = body.getType();
         persistencyContext.setRequestType(requestType);
-        final InventoryInterface inventory = config.getInventory(persistencyContext.getCertProfile(), requestType);
+        final InventoryInterface inventory = ConfigLogger.logOptional(
+                INTERFACE_NAME,
+                "Configuration.getInventory",
+                config::getInventory,
+                persistencyContext.getCertProfile(),
+                requestType);
         if (inventory != null) {
             final CertTemplate revTemplate =
                     ((RevReqContent) body.getContent()).toRevDetailsArray()[0].getCertDetails();
-            try {
-                if (!inventory.checkRevocationRequest(
-                        persistencyContext.getTransactionId(),
-                        ifNotNull(
-                                incomingRequest.getHeader().getSender(),
-                                sender -> X500Name.getInstance(sender.getName()).toString()),
-                        ifNotNull(revTemplate, template -> template.getSerialNumber()
-                                .toString()),
-                        ifNotNull(revTemplate, template -> template.getIssuer().toString()),
-                        incomingRequest.getEncoded())) {
-                    throw new CmpValidationException(
-                            INTERFACE_NAME, PKIFailureInfo.badRequest, "request refused by external inventory");
-                }
-            } catch (final IOException e) {
-                throw new CmpProcessingException(INTERFACE_NAME, PKIFailureInfo.badMessageCheck, e);
+            if (!ConfigLogger.log(
+                    INTERFACE_NAME,
+                    "InventoryInterface.checkRevocationRequest(byte[], String, String, String, byte[])",
+                    () -> {
+                        try {
+                            return inventory.checkRevocationRequest(
+                                    persistencyContext.getTransactionId(),
+                                    ifNotNull(incomingRequest.getHeader().getSender(), sender -> X500Name.getInstance(
+                                                    sender.getName())
+                                            .toString()),
+                                    ifNotNull(revTemplate, template -> template.getSerialNumber()
+                                            .toString()),
+                                    ifNotNull(revTemplate, template -> template.getIssuer()
+                                            .toString()),
+                                    incomingRequest.getEncoded());
+                        } catch (final IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    })) {
+                throw new CmpValidationException(
+                        INTERFACE_NAME, PKIFailureInfo.badRequest, "request refused by external inventory");
             }
         }
         return incomingRequest;
@@ -640,7 +717,13 @@ class RaDownstream {
                     certResponse.getCertifiedKeyPair().getCertOrEncCert().getCertificate();
             final X509Certificate enrolledCertificateAsX509 = CertUtility.asX509Certificate(enrolledCertificate);
             final TrustCredentialAdapter enrollmentValidator = new TrustCredentialAdapter(
-                    config.getEnrollmentTrust(persistencyContext.getCertProfile(), responseType));
+                    ConfigLogger.log(
+                            INTERFACE_NAME,
+                            "Configuration.getEnrollmentTrust",
+                            config::getEnrollmentTrust,
+                            persistencyContext.getCertProfile(),
+                            responseType),
+                    INTERFACE_NAME);
 
             // there is really a certificate and not only an error in the response
             // validate and fix certificate issuing chain
@@ -666,14 +749,34 @@ class RaDownstream {
             persistencyContext.setIssuingChain(issuingChain);
 
             // update inventory
-            final InventoryInterface inventory = config.getInventory(persistencyContext.getCertProfile(), responseType);
+            final InventoryInterface inventory = ConfigLogger.logOptional(
+                    INTERFACE_NAME,
+                    "Configuration.getInventory",
+                    config::getInventory,
+                    persistencyContext.getCertProfile(),
+                    responseType);
             if (inventory != null) {
-                if (!inventory.learnEnrollmentResult(
-                        persistencyContext.getTransactionId(),
-                        enrolledCertificate.getEncoded(),
-                        enrolledCertificateAsX509.getSerialNumber().toString(),
-                        enrolledCertificateAsX509.getSubjectX500Principal().toString(),
-                        enrolledCertificateAsX509.getIssuerX500Principal().toString())) {
+                if (!ConfigLogger.log(
+                        INTERFACE_NAME,
+                        "InventoryInterface.learnEnrollmentResult(byte[], byte[], String, String, String)",
+                        () -> {
+                            try {
+                                return inventory.learnEnrollmentResult(
+                                        persistencyContext.getTransactionId(),
+                                        enrolledCertificate.getEncoded(),
+                                        enrolledCertificateAsX509
+                                                .getSerialNumber()
+                                                .toString(),
+                                        enrolledCertificateAsX509
+                                                .getSubjectX500Principal()
+                                                .toString(),
+                                        enrolledCertificateAsX509
+                                                .getIssuerX500Principal()
+                                                .toString());
+                            } catch (final IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        })) {
                     throw new CmpEnrollmentException(
                             incomingRequest.getBody().getType(),
                             INTERFACE_NAME,
@@ -690,9 +793,12 @@ class RaDownstream {
             }
 
             // central key generation, respond the private key too
-            final CkgContext ckgConfiguration =
-                    config.getCkgConfiguration(persistencyContext.getCertProfile(), responseType);
-
+            final CkgContext ckgConfiguration = ConfigLogger.log(
+                    INTERFACE_NAME,
+                    "Configuration.getCkgConfiguration",
+                    config::getCkgConfiguration,
+                    persistencyContext.getCertProfile(),
+                    responseType);
             if (ckgConfiguration == null) {
                 throw new CmpEnrollmentException(
                         initialRequestType,
@@ -701,7 +807,10 @@ class RaDownstream {
                         "no credentials for private key signing available");
             }
 
-            final SignatureCredentialContext signingCredentials = ckgConfiguration.getSigningCredentials();
+            final SignatureCredentialContext signingCredentials = ConfigLogger.log(
+                    INTERFACE_NAME,
+                    "CkgContext.getSigningCredentials()",
+                    () -> ckgConfiguration.getSigningCredentials());
             if (signingCredentials == null) {
                 throw new CmpEnrollmentException(
                         initialRequestType,
@@ -709,7 +818,8 @@ class RaDownstream {
                         PKIFailureInfo.notAuthorized,
                         "central key generation configuration is missing signature credentials");
             }
-            final DataSigner keySigner = new DataSigner(new SignatureBasedProtection(signingCredentials));
+            final DataSigner keySigner =
+                    new DataSigner(new SignatureBasedProtection(signingCredentials, INTERFACE_NAME));
 
             final CmsEncryptorBase keyEncryptor =
                     buildEncryptor(incomingRequest, ckgConfiguration, initialRequestType, INTERFACE_NAME);

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/RaDownstream.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/RaDownstream.java
@@ -229,8 +229,8 @@ class RaDownstream {
                     requesterDn = sender.toString();
                 }
             }
-            final String requesterDn_final = requesterDn;
-            final CertTemplate certTemplate_final = certTemplate;
+            final String requesterDnFinal = requesterDn;
+            final CertTemplate certTemplateFinal = certTemplate;
             final CheckAndModifyResult checkResult = ConfigLogger.logOptional(
                     INTERFACE_NAME,
                     "InventoryInterface.checkAndModifyCertRequest(byte[], String, byte[], String, byte[])",
@@ -238,9 +238,9 @@ class RaDownstream {
                         try {
                             return inventory.checkAndModifyCertRequest(
                                     persistencyContext.getTransactionId(),
-                                    requesterDn_final,
-                                    certTemplate_final.getEncoded(),
-                                    ifNotNull(certTemplate_final.getSubject(), X500Name::toString),
+                                    requesterDnFinal,
+                                    certTemplateFinal.getEncoded(),
+                                    ifNotNull(certTemplateFinal.getSubject(), X500Name::toString),
                                     incomingCertificateRequest.getEncoded());
                         } catch (IOException | RuntimeException e) {
                             return null;
@@ -248,8 +248,7 @@ class RaDownstream {
                     });
 
             if (checkResult == null
-                    || !ConfigLogger.log(
-                            INTERFACE_NAME, "CheckAndModifyResult.isGranted()", () -> checkResult.isGranted())) {
+                    || !ConfigLogger.log(INTERFACE_NAME, "CheckAndModifyResult.isGranted()", checkResult::isGranted)) {
                 throw new CmpEnrollmentException(
                         requestBodyType,
                         INTERFACE_NAME,
@@ -259,7 +258,7 @@ class RaDownstream {
             final byte[] updatedCertTemplate = ConfigLogger.logOptional(
                     INTERFACE_NAME,
                     "CheckAndModifyResult.getUpdatedCertTemplate()",
-                    () -> checkResult.getUpdatedCertTemplate());
+                    checkResult::getUpdatedCertTemplate);
             if (updatedCertTemplate != null) {
                 certTemplate = CertTemplate.getInstance(updatedCertTemplate);
                 certRequest = new CertRequest(0, certTemplate, certRequest.getControls());
@@ -404,7 +403,7 @@ class RaDownstream {
                     final NestedEndpointContext nestedEndpointContext = ConfigLogger.logOptional(
                             INTERFACE_NAME,
                             "CmpMessageInterface.getNestedEndpointContext()",
-                            () -> downstreamConfiguration.getNestedEndpointContext());
+                            downstreamConfiguration::getNestedEndpointContext);
                     if (nestedEndpointContext != null) {
                         final String NESTED_INTERFACE_NAME = "nested " + INTERFACE_NAME;
                         final MessageHeaderValidator headerValidator =
@@ -415,7 +414,7 @@ class RaDownstream {
                                 ConfigLogger.logOptional(
                                         NESTED_INTERFACE_NAME,
                                         "NestedEndpointContext.getInputVerification()",
-                                        () -> nestedEndpointContext.getInputVerification()));
+                                        nestedEndpointContext::getInputVerification));
                         protectionValidator.validate(in);
                         final PKIMessage[] embeddedMessages = PKIMessages.getInstance(
                                         in.getBody().getContent())
@@ -537,9 +536,9 @@ class RaDownstream {
                         requesterDn = sender.toString();
                     }
                 }
-                final PKCS10CertificationRequest p10Request_final = p10Request;
-                final PKIMessage incomingP10Request_final = incomingP10Request;
-                final String requesterDn_final = requesterDn;
+                final PKCS10CertificationRequest p10RequestFinal = p10Request;
+                final PKIMessage incomingP10RequestFinal = incomingP10Request;
+                final String requesterDnFinal = requesterDn;
                 if (!ConfigLogger.log(
                         INTERFACE_NAME,
                         "InventoryInterface.checkP10CertRequest(byte[], String, byte[], String, byte[])",
@@ -547,10 +546,10 @@ class RaDownstream {
                             try {
                                 return inventory.checkP10CertRequest(
                                         persistencyContext.getTransactionId(),
-                                        requesterDn_final,
-                                        p10Request_final.getEncoded(),
-                                        p10Request_final.getSubject().toString(),
-                                        incomingP10Request_final.getEncoded());
+                                        requesterDnFinal,
+                                        p10RequestFinal.getEncoded(),
+                                        p10RequestFinal.getSubject().toString(),
+                                        incomingP10RequestFinal.getEncoded());
                             } catch (final IOException e) {
                                 throw new RuntimeException(e);
                             }
@@ -808,9 +807,7 @@ class RaDownstream {
             }
 
             final SignatureCredentialContext signingCredentials = ConfigLogger.log(
-                    INTERFACE_NAME,
-                    "CkgContext.getSigningCredentials()",
-                    () -> ckgConfiguration.getSigningCredentials());
+                    INTERFACE_NAME, "CkgContext.getSigningCredentials()", ckgConfiguration::getSigningCredentials);
             if (signingCredentials == null) {
                 throw new CmpEnrollmentException(
                         initialRequestType,

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/ServiceImplementation.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/ServiceImplementation.java
@@ -116,14 +116,14 @@ class ServiceImplementation {
                         }
                     }
                 }
-                final String[] dpnFullName_final = dpnFullName;
-                final String dpnNameRelativeToCRLIssuer_final = dpnNameRelativeToCRLIssuer;
+                final String[] dpnFullNameFinal = dpnFullName;
+                final String dpnNameRelativeToCRLIssuerFinal = dpnNameRelativeToCRLIssuer;
                 final List<X509CRL> crlsToAdd = ConfigLogger.logOptional(
                         INTERFACE_NAME,
                         "CrlUpdateRetrievalHandler.getCrls(String[], String, String[], Date)",
                         () -> messageHandler.getCrls(
-                                dpnFullName_final,
-                                dpnNameRelativeToCRLIssuer_final,
+                                dpnFullNameFinal,
+                                dpnNameRelativeToCRLIssuerFinal,
                                 issuers,
                                 ifNotNull(crlStatus.getThisUpdate(), Time::getDate)));
                 if (crlsToAdd != null) {
@@ -159,9 +159,7 @@ class ServiceImplementation {
             final ASN1ObjectIdentifier infoType, final GetCaCertificatesHandler messageHandler)
             throws CertificateException {
         final List<X509Certificate> caCertificates = ConfigLogger.logOptional(
-                INTERFACE_NAME,
-                "GetCaCertificatesHandler.getCaCertificates()",
-                () -> messageHandler.getCaCertificates());
+                INTERFACE_NAME, "GetCaCertificatesHandler.getCaCertificates()", messageHandler::getCaCertificates);
         if (caCertificates != null) {
             final CMPCertificate[] certificates = CertUtility.asCmpCertificates(caCertificates);
             return new PKIBody(
@@ -177,7 +175,7 @@ class ServiceImplementation {
         final byte[] template = ConfigLogger.logOptional(
                 INTERFACE_NAME,
                 "GetCertificateRequestTemplateHandler.getCertificateRequestTemplate()",
-                () -> messageHandler.getCertificateRequestTemplate());
+                messageHandler::getCertificateRequestTemplate);
         if (template != null) {
             return new PKIBody(
                     PKIBody.TYPE_GEN_REP,
@@ -203,20 +201,20 @@ class ServiceImplementation {
                 && ConfigLogger.logOptional(
                                 INTERFACE_NAME,
                                 "GetRootCaCertificateUpdateHandler.RootCaCertificateUpdateResponse.getNewWithNew()",
-                                () -> response.getNewWithNew())
+                                response::getNewWithNew)
                         != null) {
             final X509Certificate newWithNew = ConfigLogger.logOptional(
                     INTERFACE_NAME,
                     "GetRootCaCertificateUpdateHandler.RootCaCertificateUpdateResponse.getNewWithNew()",
-                    () -> response.getNewWithNew());
+                    response::getNewWithNew);
             final X509Certificate newWithOld = ConfigLogger.logOptional(
                     INTERFACE_NAME,
                     "GetRootCaCertificateUpdateHandler.RootCaCertificateUpdateResponse.getNewWithOld()",
-                    () -> response.getNewWithOld());
+                    response::getNewWithOld);
             final X509Certificate oldWithNew = ConfigLogger.logOptional(
                     INTERFACE_NAME,
                     "GetRootCaCertificateUpdateHandler.RootCaCertificateUpdateResponse.getOldWithNew()",
-                    () -> response.getOldWithNew());
+                    response::getOldWithNew);
             return new PKIBody(
                     PKIBody.TYPE_GEN_REP,
                     new GenRepContent(new InfoTypeAndValue(

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/ServiceImplementation.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/ServiceImplementation.java
@@ -31,6 +31,7 @@ import com.siemens.pki.cmpracomponent.msggeneration.MsgOutputProtector;
 import com.siemens.pki.cmpracomponent.msgvalidation.BaseCmpException;
 import com.siemens.pki.cmpracomponent.msgvalidation.CmpProcessingException;
 import com.siemens.pki.cmpracomponent.persistency.PersistencyContext;
+import com.siemens.pki.cmpracomponent.util.ConfigLogger;
 import java.io.IOException;
 import java.security.cert.CRLException;
 import java.security.cert.CertificateException;
@@ -115,11 +116,16 @@ class ServiceImplementation {
                         }
                     }
                 }
-                final List<X509CRL> crlsToAdd = messageHandler.getCrls(
-                        dpnFullName,
-                        dpnNameRelativeToCRLIssuer,
-                        issuers,
-                        ifNotNull(crlStatus.getThisUpdate(), Time::getDate));
+                final String[] dpnFullName_final = dpnFullName;
+                final String dpnNameRelativeToCRLIssuer_final = dpnNameRelativeToCRLIssuer;
+                final List<X509CRL> crlsToAdd = ConfigLogger.logOptional(
+                        INTERFACE_NAME,
+                        "CrlUpdateRetrievalHandler.getCrls(String[], String, String[], Date)",
+                        () -> messageHandler.getCrls(
+                                dpnFullName_final,
+                                dpnNameRelativeToCRLIssuer_final,
+                                issuers,
+                                ifNotNull(crlStatus.getThisUpdate(), Time::getDate)));
                 if (crlsToAdd != null) {
                     if (responseCrl == null) {
                         responseCrl = new ASN1EncodableVector();
@@ -152,7 +158,10 @@ class ServiceImplementation {
     private PKIBody handleGetCaCertificates(
             final ASN1ObjectIdentifier infoType, final GetCaCertificatesHandler messageHandler)
             throws CertificateException {
-        final List<X509Certificate> caCertificates = messageHandler.getCaCertificates();
+        final List<X509Certificate> caCertificates = ConfigLogger.logOptional(
+                INTERFACE_NAME,
+                "GetCaCertificatesHandler.getCaCertificates()",
+                () -> messageHandler.getCaCertificates());
         if (caCertificates != null) {
             final CMPCertificate[] certificates = CertUtility.asCmpCertificates(caCertificates);
             return new PKIBody(
@@ -165,7 +174,10 @@ class ServiceImplementation {
     private PKIBody handleGetCertificateRequestTemplate(
             final ASN1ObjectIdentifier infoType, final GetCertificateRequestTemplateHandler messageHandler)
             throws IOException {
-        final byte[] template = messageHandler.getCertificateRequestTemplate();
+        final byte[] template = ConfigLogger.logOptional(
+                INTERFACE_NAME,
+                "GetCertificateRequestTemplateHandler.getCertificateRequestTemplate()",
+                () -> messageHandler.getCertificateRequestTemplate());
         if (template != null) {
             return new PKIBody(
                     PKIBody.TYPE_GEN_REP,
@@ -178,12 +190,33 @@ class ServiceImplementation {
             final InfoTypeAndValue itav, final GetRootCaCertificateUpdateHandler messageHandler)
             throws CertificateException {
         final CMPCertificate oldRoot = ifNotNull(itav.getInfoValue(), CMPCertificate::getInstance);
-        final RootCaCertificateUpdateResponse response =
-                messageHandler.getRootCaCertificateUpdate(ifNotNull(oldRoot, CertUtility::asX509Certificate));
-        if (response != null && response.getNewWithNew() != null) {
-            final X509Certificate newWithNew = response.getNewWithNew();
-            final X509Certificate newWithOld = response.getNewWithOld();
-            final X509Certificate oldWithNew = response.getOldWithNew();
+        final RootCaCertificateUpdateResponse response = ConfigLogger.logOptional(
+                INTERFACE_NAME, "GetRootCaCertificateUpdateHandler.getRootCaCertificateUpdate(X509Certificate)", () -> {
+                    try {
+                        return messageHandler.getRootCaCertificateUpdate(
+                                ifNotNull(oldRoot, CertUtility::asX509Certificate));
+                    } catch (final CertificateException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+        if (response != null
+                && ConfigLogger.logOptional(
+                                INTERFACE_NAME,
+                                "GetRootCaCertificateUpdateHandler.RootCaCertificateUpdateResponse.getNewWithNew()",
+                                () -> response.getNewWithNew())
+                        != null) {
+            final X509Certificate newWithNew = ConfigLogger.logOptional(
+                    INTERFACE_NAME,
+                    "GetRootCaCertificateUpdateHandler.RootCaCertificateUpdateResponse.getNewWithNew()",
+                    () -> response.getNewWithNew());
+            final X509Certificate newWithOld = ConfigLogger.logOptional(
+                    INTERFACE_NAME,
+                    "GetRootCaCertificateUpdateHandler.RootCaCertificateUpdateResponse.getNewWithOld()",
+                    () -> response.getNewWithOld());
+            final X509Certificate oldWithNew = ConfigLogger.logOptional(
+                    INTERFACE_NAME,
+                    "GetRootCaCertificateUpdateHandler.RootCaCertificateUpdateResponse.getOldWithNew()",
+                    () -> response.getOldWithNew());
             return new PKIBody(
                     PKIBody.TYPE_GEN_REP,
                     new GenRepContent(new InfoTypeAndValue(
@@ -204,8 +237,10 @@ class ServiceImplementation {
             final InfoTypeAndValue itav = ((GenMsgContent) msg.getBody().getContent()).toInfoTypeAndValueArray()[0];
             final ASN1ObjectIdentifier infoType = itav.getInfoType();
 
-            final SupportMessageHandlerInterface messageHandler =
-                    config.getSupportMessageHandler(persistencyContext.getCertProfile(), infoType.getId());
+            final SupportMessageHandlerInterface messageHandler = ConfigLogger.logOptional(
+                    INTERFACE_NAME,
+                    "com.siemens.pki.cmpracomponent.configuration.Configuration.getSupportMessageHandler(String, String)",
+                    () -> config.getSupportMessageHandler(persistencyContext.getCertProfile(), infoType.getId()));
             if (messageHandler == null) {
                 return null;
             }
@@ -227,8 +262,12 @@ class ServiceImplementation {
                 body = new PKIBody(PKIBody.TYPE_GEN_REP, new GenRepContent(new InfoTypeAndValue(infoType)));
             }
             final MsgOutputProtector protector = new MsgOutputProtector(
-                    config.getDownstreamConfiguration(
-                            ifNotNull(persistencyContext, PersistencyContext::getCertProfile), body.getType()),
+                    ConfigLogger.log(
+                            INTERFACE_NAME,
+                            "Configuration.getDownstreamConfiguration",
+                            config::getDownstreamConfiguration,
+                            ifNotNull(persistencyContext, PersistencyContext::getCertProfile),
+                            body.getType()),
                     INTERFACE_NAME,
                     persistencyContext);
             return protector.generateAndProtectResponseTo(msg, body);

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/InputValidator.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/InputValidator.java
@@ -19,6 +19,7 @@ package com.siemens.pki.cmpracomponent.msgvalidation;
 
 import com.siemens.pki.cmpracomponent.configuration.CmpMessageInterface;
 import com.siemens.pki.cmpracomponent.persistency.PersistencyContext;
+import com.siemens.pki.cmpracomponent.util.ConfigLogger;
 import com.siemens.pki.cmpracomponent.util.MessageDumper;
 import com.siemens.pki.cmpracomponent.util.NullUtil.ExFunction;
 import java.util.Collection;
@@ -84,11 +85,20 @@ public class InputValidator implements ValidatorIF<PersistencyContext> {
                     in.getHeader().getTransactionID().getOctets());
             persistencyContext.setCertProfile(certProfile);
             certProfile = persistencyContext.getCertProfile();
-            final CmpMessageInterface cmpInterface =
-                    config.apply(certProfile, in.getBody().getType());
+            final CmpMessageInterface cmpInterface = ConfigLogger.log(
+                    interfaceName,
+                    "Configuration.getUpstreamConfiguration",
+                    config,
+                    certProfile,
+                    in.getBody().getType());
+            config.apply(certProfile, in.getBody().getType());
             new MessageBodyValidator(interfaceName, isRaVerifiedAcceptable, cmpInterface, certProfile).validate(in);
-            final ProtectionValidator protectionValidator =
-                    new ProtectionValidator(interfaceName, cmpInterface.getInputVerification());
+            final ProtectionValidator protectionValidator = new ProtectionValidator(
+                    interfaceName,
+                    ConfigLogger.logOptional(
+                            interfaceName,
+                            "CmpMessageInterface.getInputVerification()",
+                            () -> cmpInterface.getInputVerification()));
             protectionValidator.validate(in);
             return persistencyContext;
         } catch (final BaseCmpException ce) {

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/InputValidator.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/InputValidator.java
@@ -98,7 +98,7 @@ public class InputValidator implements ValidatorIF<PersistencyContext> {
                     ConfigLogger.logOptional(
                             interfaceName,
                             "CmpMessageInterface.getInputVerification()",
-                            () -> cmpInterface.getInputVerification()));
+                            cmpInterface::getInputVerification));
             protectionValidator.validate(in);
             return persistencyContext;
         } catch (final BaseCmpException ce) {

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/MacValidator.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/MacValidator.java
@@ -17,9 +17,9 @@
  */
 package com.siemens.pki.cmpracomponent.msgvalidation;
 
-import static com.siemens.pki.cmpracomponent.util.NullUtil.ifNotNull;
-
 import com.siemens.pki.cmpracomponent.configuration.VerificationContext;
+import com.siemens.pki.cmpracomponent.util.ConfigLogger;
+import com.siemens.pki.cmpracomponent.util.NullUtil;
 import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.cmp.PKIFailureInfo;
 import org.bouncycastle.asn1.cmp.PKIHeader;
@@ -42,9 +42,10 @@ public abstract class MacValidator implements ValidatorIF<Void> {
     }
 
     protected byte[] getSharedSecret(final PKIHeader header) throws CmpValidationException {
-        final byte[] passwordAsBytes =
-                config.getSharedSecret(ifNotNull(header.getSenderKID(), ASN1OctetString::getOctets));
-
+        final byte[] passwordAsBytes = ConfigLogger.logOptional(
+                interfaceName,
+                "VerificationContext.getSharedSecret(byte[])",
+                () -> config.getSharedSecret(NullUtil.ifNotNull(header.getSenderKID(), ASN1OctetString::getOctets)));
         if (passwordAsBytes == null) {
             throw new CmpValidationException(
                     getInterfaceName(),

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/MessageBodyValidator.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/MessageBodyValidator.java
@@ -19,6 +19,7 @@ package com.siemens.pki.cmpracomponent.msgvalidation;
 
 import com.siemens.pki.cmpracomponent.configuration.CmpMessageInterface;
 import com.siemens.pki.cmpracomponent.cryptoservices.CertUtility;
+import com.siemens.pki.cmpracomponent.util.ConfigLogger;
 import com.siemens.pki.cmpracomponent.util.MessageDumper;
 import java.io.IOException;
 import java.math.BigInteger;
@@ -191,7 +192,10 @@ public class MessageBodyValidator implements ValidatorIF<String> {
             final ASN1GeneralizedTime messageTime = message.getHeader().getMessageTime();
             if (messageTime != null) {
                 final long diffInMillis = messageTime.getDate().getTime() - new Date().getTime();
-                if (!cmpInterfaceConfig.isMessageTimeDeviationAllowed(diffInMillis / 1000L)) {
+                if (!ConfigLogger.log(
+                        interfaceName,
+                        "CmpMessageInterface.isMessageTimeDeviationAllowed(long)",
+                        () -> cmpInterfaceConfig.isMessageTimeDeviationAllowed(diffInMillis / 1000L))) {
                     throw new CmpValidationException(
                             interfaceName, PKIFailureInfo.badTime, "message time out of allowed range");
                 }
@@ -321,7 +325,12 @@ public class MessageBodyValidator implements ValidatorIF<String> {
         } else {
             switch (popo.getType()) {
                 case ProofOfPossession.TYPE_RA_VERIFIED:
-                    if (!isRaVerifiedAcceptable.test(certProfile, bodyType)) {
+                    if (!ConfigLogger.log(
+                            interfaceName,
+                            "Configuration.isRaVerifiedAcceptable",
+                            isRaVerifiedAcceptable::test,
+                            certProfile,
+                            bodyType)) {
                         throw new CmpEnrollmentException(
                                 enrollmentType, interfaceName, PKIFailureInfo.badPOP, "POPO RaVerified not allowed");
                     }

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/PBMAC1ProtectionValidator.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/PBMAC1ProtectionValidator.java
@@ -79,7 +79,7 @@ public class PBMAC1ProtectionValidator extends MacValidator {
             final byte[] protectionBytes = message.getProtection().getBytes();
             if (!Arrays.equals(recalculatedProtection, protectionBytes)) {
                 throw new CmpValidationException(
-                        getInterfaceName(), PKIFailureInfo.badMessageCheck, "PasswordBasedMac protection check failed");
+                        getInterfaceName(), PKIFailureInfo.badMessageCheck, "PBMAC1 protection check failed");
             }
         } catch (final BaseCmpException cex) {
             throw cex;

--- a/src/main/java/com/siemens/pki/cmpracomponent/protection/MacProtection.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/protection/MacProtection.java
@@ -22,6 +22,7 @@ import static com.siemens.pki.cmpracomponent.util.NullUtil.ifNotNull;
 
 import com.siemens.pki.cmpracomponent.configuration.SharedSecretCredentialContext;
 import com.siemens.pki.cmpracomponent.cryptoservices.WrappedMac;
+import com.siemens.pki.cmpracomponent.util.ConfigLogger;
 import java.util.List;
 import org.bouncycastle.asn1.ASN1Encoding;
 import org.bouncycastle.asn1.DERBitString;
@@ -42,8 +43,11 @@ public abstract class MacProtection implements ProtectionProvider {
 
     private WrappedMac protectingMac;
 
-    protected MacProtection(final SharedSecretCredentialContext config) {
+    protected String interfaceName;
+
+    protected MacProtection(final SharedSecretCredentialContext config, String interfaceName) {
         this.config = config;
+        this.interfaceName = interfaceName;
     }
 
     @Override
@@ -68,7 +72,10 @@ public abstract class MacProtection implements ProtectionProvider {
 
     @Override
     public DEROctetString getSenderKID() {
-        return ifNotNull(config.getSenderKID(), DEROctetString::new);
+        return ifNotNull(
+                ConfigLogger.logOptional(
+                        interfaceName, "SharedSecretCredentialContext.getSenderKID()", () -> config.getSenderKID()),
+                DEROctetString::new);
     }
 
     /**

--- a/src/main/java/com/siemens/pki/cmpracomponent/protection/MacProtection.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/protection/MacProtection.java
@@ -74,7 +74,7 @@ public abstract class MacProtection implements ProtectionProvider {
     public DEROctetString getSenderKID() {
         return ifNotNull(
                 ConfigLogger.logOptional(
-                        interfaceName, "SharedSecretCredentialContext.getSenderKID()", () -> config.getSenderKID()),
+                        interfaceName, "SharedSecretCredentialContext.getSenderKID()", config::getSenderKID),
                 DEROctetString::new);
     }
 

--- a/src/main/java/com/siemens/pki/cmpracomponent/protection/PBMAC1Protection.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/protection/PBMAC1Protection.java
@@ -49,13 +49,12 @@ public class PBMAC1Protection extends MacProtection {
     public PBMAC1Protection(final SharedSecretCredentialContext config, String interfaceName)
             throws InvalidKeySpecException, InvalidKeyException, NoSuchAlgorithmException {
         super(config, interfaceName);
-        final byte[] salt =
-                ConfigLogger.log(interfaceName, "SharedSecretCredentialContext.getSalt()", () -> config.getSalt());
-        final AlgorithmIdentifier prfAlgorithm = AlgorithmHelper.getPrf(ConfigLogger.log(
-                        interfaceName, "SharedSecretCredentialContext.getPrf()", () -> config.getPrf()))
+        final byte[] salt = ConfigLogger.log(interfaceName, "SharedSecretCredentialContext.getSalt()", config::getSalt);
+        final AlgorithmIdentifier prfAlgorithm = AlgorithmHelper.getPrf(
+                        ConfigLogger.log(interfaceName, "SharedSecretCredentialContext.getPrf()", config::getPrf))
                 .getAlgorithmID();
-        final int keyLength = ConfigLogger.log(
-                interfaceName, "SharedSecretCredentialContext.getkeyLength()", () -> config.getkeyLength());
+        final int keyLength =
+                ConfigLogger.log(interfaceName, "SharedSecretCredentialContext.getkeyLength()", config::getkeyLength);
         final AlgorithmIdentifier keyDerivationFunc = new AlgorithmIdentifier(
                 PKCSObjectIdentifiers.id_PBKDF2,
                 new PBKDF2Params(
@@ -63,7 +62,7 @@ public class PBMAC1Protection extends MacProtection {
                         ConfigLogger.log(
                                 interfaceName,
                                 "SharedSecretCredentialContext.getIterationCount()",
-                                () -> config.getIterationCount()),
+                                config::getIterationCount),
                         keyLength,
                         prfAlgorithm));
         final SecretKeyFactory keyFact =
@@ -75,9 +74,7 @@ public class PBMAC1Protection extends MacProtection {
                 keyLength));
         final AlgorithmIdentifier messageAuthScheme =
                 new AlgorithmIdentifier(AlgorithmHelper.getOidForMac(ConfigLogger.log(
-                        interfaceName,
-                        "SharedSecretCredentialContext.getMacAlgorithm()",
-                        () -> config.getMacAlgorithm())));
+                        interfaceName, "SharedSecretCredentialContext.getMacAlgorithm()", config::getMacAlgorithm)));
         final AlgorithmIdentifier protectionAlg = new AlgorithmIdentifier(
                 PKCSObjectIdentifiers.id_PBMAC1, new PBMAC1Params(keyDerivationFunc, messageAuthScheme));
         final WrappedMac wrappedMac = WrappedMacFactory.createWrappedMac(messageAuthScheme, key.getEncoded());

--- a/src/main/java/com/siemens/pki/cmpracomponent/protection/PasswordBasedMacProtection.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/protection/PasswordBasedMacProtection.java
@@ -47,24 +47,24 @@ public class PasswordBasedMacProtection extends MacProtection {
         super(config, interfaceName);
 
         final byte[] raSecret = ConfigLogger.log(
-                interfaceName, "SharedSecretCredentialContext.getSharedSecret()", () -> config.getSharedSecret());
+                interfaceName, "SharedSecretCredentialContext.getSharedSecret()", config::getSharedSecret);
 
         final byte[] protectionSalt =
-                ConfigLogger.log(interfaceName, "SharedSecretCredentialContext.getSalt()", () -> config.getSalt());
+                ConfigLogger.log(interfaceName, "SharedSecretCredentialContext.getSalt()", config::getSalt);
         byte[] calculatingBaseKey = new byte[raSecret.length + protectionSalt.length];
         System.arraycopy(raSecret, 0, calculatingBaseKey, 0, raSecret.length);
         System.arraycopy(protectionSalt, 0, calculatingBaseKey, raSecret.length, protectionSalt.length);
         // Construct the base key according to rfc4210, section 5.1.3.1
         final MessageDigest dig = AlgorithmHelper.getMessageDigest(
-                ConfigLogger.log(interfaceName, "SharedSecretCredentialContext.getPrf()", () -> config.getPrf()));
+                ConfigLogger.log(interfaceName, "SharedSecretCredentialContext.getPrf()", config::getPrf));
         final int iterationCount = ConfigLogger.log(
-                interfaceName, "SharedSecretCredentialContext.getIterationCount()", () -> config.getIterationCount());
+                interfaceName, "SharedSecretCredentialContext.getIterationCount()", config::getIterationCount);
         for (int i = 0; i < iterationCount; i++) {
             calculatingBaseKey = dig.digest(calculatingBaseKey);
             dig.reset();
         }
         final AlgorithmIdentifier macAlgorithm = new AlgorithmIdentifier(AlgorithmHelper.getOidForMac(ConfigLogger.log(
-                interfaceName, "SharedSecretCredentialContext.getMacAlgorithm()", () -> config.getMacAlgorithm())));
+                interfaceName, "SharedSecretCredentialContext.getMacAlgorithm()", config::getMacAlgorithm)));
         final Mac protectingMac =
                 AlgorithmHelper.getMac(macAlgorithm.getAlgorithm().getId());
         protectingMac.init(new SecretKeySpec(calculatingBaseKey, protectingMac.getAlgorithm()));

--- a/src/main/java/com/siemens/pki/cmpracomponent/protection/PasswordBasedMacProtection.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/protection/PasswordBasedMacProtection.java
@@ -20,6 +20,7 @@ package com.siemens.pki.cmpracomponent.protection;
 import com.siemens.pki.cmpracomponent.configuration.SharedSecretCredentialContext;
 import com.siemens.pki.cmpracomponent.cryptoservices.AlgorithmHelper;
 import com.siemens.pki.cmpracomponent.cryptoservices.WrappedMac;
+import com.siemens.pki.cmpracomponent.util.ConfigLogger;
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -37,28 +38,33 @@ public class PasswordBasedMacProtection extends MacProtection {
     /**
      * ctor
      * @param config specific configuration
+     * @param interfaceName CMP interface name for logging
      * @throws InvalidKeyException      in case of internal error
      * @throws NoSuchAlgorithmException in case of unsupported algorithm
      */
-    public PasswordBasedMacProtection(final SharedSecretCredentialContext config)
+    public PasswordBasedMacProtection(final SharedSecretCredentialContext config, String interfaceName)
             throws InvalidKeyException, NoSuchAlgorithmException {
-        super(config);
+        super(config, interfaceName);
 
-        final byte[] raSecret = config.getSharedSecret();
+        final byte[] raSecret = ConfigLogger.log(
+                interfaceName, "SharedSecretCredentialContext.getSharedSecret()", () -> config.getSharedSecret());
 
-        final byte[] protectionSalt = config.getSalt();
+        final byte[] protectionSalt =
+                ConfigLogger.log(interfaceName, "SharedSecretCredentialContext.getSalt()", () -> config.getSalt());
         byte[] calculatingBaseKey = new byte[raSecret.length + protectionSalt.length];
         System.arraycopy(raSecret, 0, calculatingBaseKey, 0, raSecret.length);
         System.arraycopy(protectionSalt, 0, calculatingBaseKey, raSecret.length, protectionSalt.length);
         // Construct the base key according to rfc4210, section 5.1.3.1
-        final MessageDigest dig = AlgorithmHelper.getMessageDigest(config.getPrf());
-        final int iterationCount = config.getIterationCount();
+        final MessageDigest dig = AlgorithmHelper.getMessageDigest(
+                ConfigLogger.log(interfaceName, "SharedSecretCredentialContext.getPrf()", () -> config.getPrf()));
+        final int iterationCount = ConfigLogger.log(
+                interfaceName, "SharedSecretCredentialContext.getIterationCount()", () -> config.getIterationCount());
         for (int i = 0; i < iterationCount; i++) {
             calculatingBaseKey = dig.digest(calculatingBaseKey);
             dig.reset();
         }
-        final AlgorithmIdentifier macAlgorithm =
-                new AlgorithmIdentifier(AlgorithmHelper.getOidForMac(config.getMacAlgorithm()));
+        final AlgorithmIdentifier macAlgorithm = new AlgorithmIdentifier(AlgorithmHelper.getOidForMac(ConfigLogger.log(
+                interfaceName, "SharedSecretCredentialContext.getMacAlgorithm()", () -> config.getMacAlgorithm())));
         final Mac protectingMac =
                 AlgorithmHelper.getMac(macAlgorithm.getAlgorithm().getId());
         protectingMac.init(new SecretKeySpec(calculatingBaseKey, protectingMac.getAlgorithm()));

--- a/src/main/java/com/siemens/pki/cmpracomponent/protection/ProtectionProviderFactory.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/protection/ProtectionProviderFactory.java
@@ -20,6 +20,7 @@ package com.siemens.pki.cmpracomponent.protection;
 import com.siemens.pki.cmpracomponent.configuration.CredentialContext;
 import com.siemens.pki.cmpracomponent.configuration.SharedSecretCredentialContext;
 import com.siemens.pki.cmpracomponent.configuration.SignatureCredentialContext;
+import com.siemens.pki.cmpracomponent.util.ConfigLogger;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
@@ -29,39 +30,44 @@ import java.security.spec.InvalidKeySpecException;
  */
 public class ProtectionProviderFactory {
 
-    // utility class
-    private ProtectionProviderFactory() {}
-
     /**
      * create a {@link ProtectionProvider} according to the given configuration
      *
      * @param config specific configuration
+     * @param interfaceName CMP interface name for logging
      * @return a new {@link ProtectionProvider}
      * @throws NoSuchAlgorithmException in case of unknown algorithm
      * @throws InvalidKeyException      in case of internal error
      * @throws InvalidKeySpecException  in case of internal error
      */
-    public static ProtectionProvider createProtectionProvider(final CredentialContext config)
+    public static ProtectionProvider createProtectionProvider(final CredentialContext config, String interfaceName)
             throws InvalidKeyException, NoSuchAlgorithmException, InvalidKeySpecException {
         if (config instanceof SharedSecretCredentialContext) {
             final SharedSecretCredentialContext ssConfig = (SharedSecretCredentialContext) config;
-            switch (ssConfig.getPasswordBasedMacAlgorithm().toLowerCase()) {
+            final String passwordBasedMacAlgorithm = ConfigLogger.log(
+                    interfaceName,
+                    "SharedSecretCredentialContext.getPasswordBasedMacAlgorithm()",
+                    () -> ssConfig.getPasswordBasedMacAlgorithm());
+            switch (passwordBasedMacAlgorithm.toLowerCase()) {
                 case "1.2.840.113533.7.66.13":
                 case "id-passwordbasedmac":
                 case "passwordbasedmac":
                 case "pbm":
-                    return new PasswordBasedMacProtection(ssConfig);
+                    return new PasswordBasedMacProtection(ssConfig, interfaceName);
                 case "1.2.840.113549.1.5.14":
                 case "id-pbmac1":
                 case "pbmac1":
-                    return new PBMAC1Protection(ssConfig);
+                    return new PBMAC1Protection(ssConfig, interfaceName);
                 default:
-                    throw new NoSuchAlgorithmException(ssConfig.getPasswordBasedMacAlgorithm());
+                    throw new NoSuchAlgorithmException(passwordBasedMacAlgorithm);
             }
         }
         if (config instanceof SignatureCredentialContext) {
-            return new SignatureBasedProtection((SignatureCredentialContext) config);
+            return new SignatureBasedProtection((SignatureCredentialContext) config, interfaceName);
         }
         return ProtectionProvider.NO_PROTECTION;
     }
+
+    // utility class
+    private ProtectionProviderFactory() {}
 }

--- a/src/main/java/com/siemens/pki/cmpracomponent/protection/ProtectionProviderFactory.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/protection/ProtectionProviderFactory.java
@@ -47,7 +47,7 @@ public class ProtectionProviderFactory {
             final String passwordBasedMacAlgorithm = ConfigLogger.log(
                     interfaceName,
                     "SharedSecretCredentialContext.getPasswordBasedMacAlgorithm()",
-                    () -> ssConfig.getPasswordBasedMacAlgorithm());
+                    ssConfig::getPasswordBasedMacAlgorithm);
             switch (passwordBasedMacAlgorithm.toLowerCase()) {
                 case "1.2.840.113533.7.66.13":
                 case "id-passwordbasedmac":

--- a/src/main/java/com/siemens/pki/cmpracomponent/protection/SignatureBasedProtection.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/protection/SignatureBasedProtection.java
@@ -44,9 +44,10 @@ public class SignatureBasedProtection extends BaseCredentialService implements P
     /**
      * ctor
      * @param config specific configuration
+     * @param interfaceName CMP interface name for logging
      */
-    public SignatureBasedProtection(final SignatureCredentialContext config) {
-        super(config);
+    public SignatureBasedProtection(final SignatureCredentialContext config, String interfaceName) {
+        super(config, interfaceName);
     }
 
     @Override

--- a/src/main/java/com/siemens/pki/cmpracomponent/util/ConfigLogger.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/util/ConfigLogger.java
@@ -1,0 +1,240 @@
+/*
+ *  Copyright (c) 2024 Siemens AG
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+package com.siemens.pki.cmpracomponent.util;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import org.bouncycastle.util.encoders.Hex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * helper class for configuration access logging
+ */
+public class ConfigLogger {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigLogger.class);
+
+    private static <T> void doInnerLogging(
+            String interfaceName, String accessFunctionName, String certProfile, Integer bodyType, T ret) {
+        if (LOGGER.isDebugEnabled()) {
+            final String logMsg = "call {}({}, {}) for \"{}\" -> {}";
+            if (ret instanceof byte[]) {
+                LOGGER.debug(
+                        logMsg,
+                        accessFunctionName,
+                        certProfile,
+                        typeToString(bodyType),
+                        interfaceName,
+                        Hex.toHexString((byte[]) ret));
+            } else if (ret instanceof Collection<?>) {
+                LOGGER.debug(
+                        logMsg,
+                        accessFunctionName,
+                        certProfile,
+                        typeToString(bodyType),
+                        interfaceName,
+                        Arrays.toString(((Collection<?>) ret).toArray()));
+            } else if (ret != null && ret.getClass().isArray()) {
+                LOGGER.debug(
+                        logMsg,
+                        accessFunctionName,
+                        certProfile,
+                        typeToString(bodyType),
+                        interfaceName,
+                        Arrays.toString((Object[]) ret));
+            } else {
+                LOGGER.debug(logMsg, accessFunctionName, certProfile, typeToString(bodyType), interfaceName, ret);
+            }
+        }
+    }
+
+    private static <T> void doInnerLogging(String interfaceName, String accessFunctionName, T ret) {
+        if (LOGGER.isDebugEnabled()) {
+            final String logMsg = "call {} for \"{}\" -> {}";
+            if (ret instanceof byte[]) {
+                LOGGER.debug(logMsg, accessFunctionName, interfaceName, Hex.toHexString((byte[]) ret));
+            } else if (ret instanceof Collection<?>) {
+                LOGGER.debug(
+                        logMsg, accessFunctionName, interfaceName, Arrays.toString(((Collection<?>) ret).toArray()));
+            } else if (ret != null && ret.getClass().isArray()) {
+                LOGGER.debug(logMsg, accessFunctionName, interfaceName, Arrays.toString((Object[]) ret));
+            } else {
+                LOGGER.debug(logMsg, accessFunctionName, interfaceName, ret);
+            }
+        }
+    }
+
+    /**
+     * log access to mandatory configuration value
+     *
+     * @param <T>                return type of access function
+     * @param interfaceName      related interface of configuration
+     * @param accessFunctionName name of access function
+     * @param accessFunction     the access function
+     * @param certProfile certificate profile extracted from the CMP request header
+     *                    generalInfo field or <code>null</code> if no certificate
+     *                    profile was specified
+     * @param bodyType    request/response PKI Message Body type
+     * @return return value of access function
+     * @throws NullPointerException if return value was <code>null</code>
+     */
+    public static <T> T log(
+            String interfaceName,
+            String accessFunctionName,
+            BiFunction<String, Integer, T> accessFunction,
+            String certProfile,
+            Integer bodyType) {
+        T ret;
+        try {
+            ret = accessFunction.apply(certProfile, bodyType);
+        } catch (final Throwable ex) {
+            LOGGER.error(
+                    "exception calling " + accessFunctionName + "(" + certProfile + ", " + typeToString(bodyType)
+                            + ") for \"" + interfaceName + "\"",
+                    ex);
+            Throwable cause = ex.getCause();
+            while (cause != null) {
+                LOGGER.error("cause", cause);
+                cause = cause.getCause();
+            }
+            throw ex;
+        }
+        doInnerLogging(interfaceName, accessFunctionName, certProfile, bodyType, ret);
+        if (ret == null) {
+            final String logMsg = "calling " + accessFunctionName + "(" + certProfile + ", " + typeToString(bodyType)
+                    + ") for \"" + interfaceName + "\" returns null, but this configuration item is mandatory";
+            LOGGER.error(logMsg);
+            throw new NullPointerException(logMsg);
+        }
+        return ret;
+    }
+
+    /**
+     * log access to mandatory configuration value
+     *
+     * @param <T>                return type of access function
+     * @param interfaceName      related interface of configuration
+     * @param accessFunctionName name of access function
+     * @param accessFunction     the access function
+     * @return return value of access function
+     * @throws NullPointerException if return value was <code>null</code>
+     */
+    public static <T> T log(String interfaceName, String accessFunctionName, Supplier<T> accessFunction) {
+        T ret;
+        try {
+            ret = accessFunction.get();
+        } catch (final Throwable ex) {
+            LOGGER.error("exception calling " + accessFunctionName + " for \"" + interfaceName + "\"", ex);
+            Throwable cause = ex.getCause();
+            while (cause != null) {
+                LOGGER.error("cause", cause);
+                cause = cause.getCause();
+            }
+            throw ex;
+        }
+        doInnerLogging(interfaceName, accessFunctionName, ret);
+        if (ret == null) {
+            final String logMsg = "calling " + accessFunctionName + " for \"" + interfaceName
+                    + "\" returns null, but this configuration item is mandatory";
+            LOGGER.error(logMsg);
+            throw new NullPointerException(logMsg);
+        }
+        return ret;
+    }
+
+    /**
+     * log access to optional configuration value
+     *
+     * @param <T>                return type of access function
+     * @param interfaceName      related interface of configuration
+     * @param accessFunctionName name of access function
+     * @param accessFunction     the access function
+     * @param certProfile certificate profile extracted from the CMP request header
+     *                    generalInfo field or <code>null</code> if no certificate
+     *                    profile was specified
+     * @param bodyType    request/response PKI Message Body type
+     * @return return value of access function
+     * @throws NullPointerException if return value of access function was
+     *                              <code>null</code>
+     */
+    public static <T> T logOptional(
+            String interfaceName,
+            String accessFunctionName,
+            BiFunction<String, Integer, T> accessFunction,
+            String certProfile,
+            Integer bodyType) {
+        T ret;
+        try {
+            ret = accessFunction.apply(certProfile, bodyType);
+        } catch (final Throwable ex) {
+            LOGGER.error(
+                    "exception calling " + accessFunctionName + "(" + certProfile + ", " + typeToString(bodyType)
+                            + ") for \"" + interfaceName + "\", proceed without configuration",
+                    ex);
+            Throwable cause = ex.getCause();
+            while (cause != null) {
+                LOGGER.error("cause", cause);
+                cause = cause.getCause();
+            }
+            return null;
+        }
+        doInnerLogging(interfaceName, accessFunctionName, certProfile, bodyType, ret);
+        return ret;
+    }
+
+    /**
+     * log access to optional configuration value
+     *
+     * @param <T>                return type of access function
+     * @param interfaceName      related interface of configuration
+     * @param accessFunctionName name of access function
+     * @param accessFunction     the access function
+     * @return return value of access function
+     * @throws NullPointerException if return value of access function was
+     *                              <code>null</code>
+     */
+    public static <T> T logOptional(String interfaceName, String accessFunctionName, Supplier<T> accessFunction) {
+        T ret;
+        try {
+            ret = accessFunction.get();
+        } catch (final Throwable ex) {
+            LOGGER.error(
+                    "exception while calling " + accessFunctionName + " for  \"" + interfaceName
+                            + "\", proceed without configuration",
+                    ex);
+            Throwable cause = ex.getCause();
+            while (cause != null) {
+                LOGGER.error("cause", cause);
+                cause = cause.getCause();
+            }
+            return null;
+        }
+        doInnerLogging(interfaceName, accessFunctionName, ret);
+        return ret;
+    }
+
+    private static String typeToString(Integer bodyType) {
+        if (bodyType == null) {
+            return "<null>";
+        }
+        return MessageDumper.msgTypeAsString(bodyType) + "(" + bodyType + ")";
+    }
+}

--- a/src/main/java/com/siemens/pki/cmpracomponent/util/ConfigLogger.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/util/ConfigLogger.java
@@ -237,4 +237,6 @@ public class ConfigLogger {
         }
         return MessageDumper.msgTypeAsString(bodyType) + "(" + bodyType + ")";
     }
+    // utility class
+    private ConfigLogger() {}
 }

--- a/src/main/java/com/siemens/pki/cmpracomponent/util/ConfigLogger.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/util/ConfigLogger.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ConfigLogger {
 
+    private static final String DYNAMIC_CONFIGURATION_EXCEPTION = "DynamicConfigurationException: ";
     private static final Logger LOGGER = LoggerFactory.getLogger(ConfigLogger.class);
 
     private static <T> void doInnerLogging(
@@ -106,23 +107,22 @@ public class ConfigLogger {
         try {
             ret = accessFunction.apply(certProfile, bodyType);
         } catch (final Throwable ex) {
-            LOGGER.error(
-                    "exception calling " + accessFunctionName + "(" + certProfile + ", " + typeToString(bodyType)
-                            + ") for \"" + interfaceName + "\"",
-                    ex);
+            final String errorMsg = "exception calling " + accessFunctionName + "(" + certProfile + ", "
+                    + typeToString(bodyType) + ") for \"" + interfaceName + "\"";
+            LOGGER.error(errorMsg, ex);
             Throwable cause = ex.getCause();
             while (cause != null) {
                 LOGGER.error("cause", cause);
                 cause = cause.getCause();
             }
-            throw ex;
+            throw new RuntimeException(DYNAMIC_CONFIGURATION_EXCEPTION + errorMsg, ex);
         }
         doInnerLogging(interfaceName, accessFunctionName, certProfile, bodyType, ret);
         if (ret == null) {
             final String logMsg = "calling " + accessFunctionName + "(" + certProfile + ", " + typeToString(bodyType)
                     + ") for \"" + interfaceName + "\" returns null, but this configuration item is mandatory";
             LOGGER.error(logMsg);
-            throw new NullPointerException(logMsg);
+            throw new RuntimeException(DYNAMIC_CONFIGURATION_EXCEPTION + logMsg);
         }
         return ret;
     }
@@ -142,20 +142,21 @@ public class ConfigLogger {
         try {
             ret = accessFunction.get();
         } catch (final Throwable ex) {
-            LOGGER.error("exception calling " + accessFunctionName + " for \"" + interfaceName + "\"", ex);
+            final String errorMsg = "exception calling " + accessFunctionName + " for \"" + interfaceName + "\"";
+            LOGGER.error(errorMsg, ex);
             Throwable cause = ex.getCause();
             while (cause != null) {
                 LOGGER.error("cause", cause);
                 cause = cause.getCause();
             }
-            throw ex;
+            throw new RuntimeException(DYNAMIC_CONFIGURATION_EXCEPTION + errorMsg, ex);
         }
         doInnerLogging(interfaceName, accessFunctionName, ret);
         if (ret == null) {
             final String logMsg = "calling " + accessFunctionName + " for \"" + interfaceName
                     + "\" returns null, but this configuration item is mandatory";
             LOGGER.error(logMsg);
-            throw new NullPointerException(logMsg);
+            throw new RuntimeException(DYNAMIC_CONFIGURATION_EXCEPTION + logMsg);
         }
         return ret;
     }
@@ -185,16 +186,15 @@ public class ConfigLogger {
         try {
             ret = accessFunction.apply(certProfile, bodyType);
         } catch (final Throwable ex) {
-            LOGGER.error(
-                    "exception calling " + accessFunctionName + "(" + certProfile + ", " + typeToString(bodyType)
-                            + ") for \"" + interfaceName + "\", proceed without configuration",
-                    ex);
+            final String errorMsg = "exception calling " + accessFunctionName + "(" + certProfile + ", "
+                    + typeToString(bodyType) + ") for \"" + interfaceName + "\"";
+            LOGGER.error(errorMsg, ex);
             Throwable cause = ex.getCause();
             while (cause != null) {
                 LOGGER.error("cause", cause);
                 cause = cause.getCause();
             }
-            return null;
+            throw new RuntimeException(DYNAMIC_CONFIGURATION_EXCEPTION + errorMsg, ex);
         }
         doInnerLogging(interfaceName, accessFunctionName, certProfile, bodyType, ret);
         return ret;
@@ -216,16 +216,14 @@ public class ConfigLogger {
         try {
             ret = accessFunction.get();
         } catch (final Throwable ex) {
-            LOGGER.error(
-                    "exception while calling " + accessFunctionName + " for  \"" + interfaceName
-                            + "\", proceed without configuration",
-                    ex);
+            final String errorMsg = "exception while calling " + accessFunctionName + " for  \"" + interfaceName + "\"";
+            LOGGER.error(errorMsg, ex);
             Throwable cause = ex.getCause();
             while (cause != null) {
                 LOGGER.error("cause", cause);
                 cause = cause.getCause();
             }
-            return null;
+            throw new RuntimeException(DYNAMIC_CONFIGURATION_EXCEPTION + errorMsg, ex);
         }
         doInnerLogging(interfaceName, accessFunctionName, ret);
         return ret;

--- a/src/test/java/com/siemens/pki/cmpclientcomponent/test/EnrollmentTestcaseBase.java
+++ b/src/test/java/com/siemens/pki/cmpclientcomponent/test/EnrollmentTestcaseBase.java
@@ -31,6 +31,8 @@ import java.util.List;
 
 public class EnrollmentTestcaseBase extends CmpClientTestcaseBase {
 
+    protected String INTERFACE_NAME = "testclient";
+
     SignatureValidationCredentials enrollmentCredentials;
 
     ClientContext getClientContext(final int enrollmentType, KeyPair keyPair, byte[] certificationRequest) {

--- a/src/test/java/com/siemens/pki/cmpclientcomponent/test/TestCentralKeyGenerationWithKeyAgreement.java
+++ b/src/test/java/com/siemens/pki/cmpclientcomponent/test/TestCentralKeyGenerationWithKeyAgreement.java
@@ -66,7 +66,7 @@ public class TestCentralKeyGenerationWithKeyAgreement extends EnrollmentTestcase
     public static final String DEFAULT_KEY_ENCRYPTION = "AES256_WRAP";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TestCentralKeyGenerationWithKeyAgreement.class);
-    public static Object[][] inputList = new Object[][] {
+    public static Object[][] inputList = {
         //
         {DEFAULT_KEY_AGREEMENT, DEFAULT_KEY_ENCRYPTION},
         //
@@ -464,7 +464,7 @@ public class TestCentralKeyGenerationWithKeyAgreement extends EnrollmentTestcase
                 .invokeEnrollment();
         assertNotNull(ret);
         // try to use received certificate and key
-        final DataSigner testSigner = new DataSigner(ret.getPrivateKey(), ret.getEnrolledCertificate());
+        final DataSigner testSigner = new DataSigner(ret.getPrivateKey(), ret.getEnrolledCertificate(), INTERFACE_NAME);
         final byte[] msgToSign = "Hello Signer, I am the message".getBytes();
         assertArrayEquals(
                 msgToSign,

--- a/src/test/java/com/siemens/pki/cmpclientcomponent/test/TestCentralKeyGenerationWithKeyTransport.java
+++ b/src/test/java/com/siemens/pki/cmpclientcomponent/test/TestCentralKeyGenerationWithKeyTransport.java
@@ -418,7 +418,7 @@ public class TestCentralKeyGenerationWithKeyTransport extends EnrollmentTestcase
                 .invokeEnrollment();
         assertNotNull(ret);
         // try to use received certificate and key
-        final DataSigner testSigner = new DataSigner(ret.getPrivateKey(), ret.getEnrolledCertificate());
+        final DataSigner testSigner = new DataSigner(ret.getPrivateKey(), ret.getEnrolledCertificate(), INTERFACE_NAME);
         final byte[] msgToSign = "Hello Signer, I am the message".getBytes();
         assertArrayEquals(
                 msgToSign,

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/CkgOnlineEnrollmentTestcaseBase.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/CkgOnlineEnrollmentTestcaseBase.java
@@ -17,20 +17,32 @@
  */
 package com.siemens.pki.cmpracomponent.test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import com.siemens.pki.cmpracomponent.cryptoservices.CmsDecryptor;
 import com.siemens.pki.cmpracomponent.cryptoservices.DataSignVerifier;
 import com.siemens.pki.cmpracomponent.cryptoservices.DataSigner;
 import com.siemens.pki.cmpracomponent.msggeneration.PkiMessageGenerator;
 import com.siemens.pki.cmpracomponent.protection.ProtectionProvider;
-import com.siemens.pki.cmpracomponent.test.framework.*;
+import com.siemens.pki.cmpracomponent.test.framework.ConfigurationFactory;
+import com.siemens.pki.cmpracomponent.test.framework.EnrollmentResult;
+import com.siemens.pki.cmpracomponent.test.framework.HeaderProviderForTest;
+import com.siemens.pki.cmpracomponent.test.framework.SignatureValidationCredentials;
+import com.siemens.pki.cmpracomponent.test.framework.TestCertUtility;
 import com.siemens.pki.cmpracomponent.util.MessageDumper;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.util.function.Function;
 import org.bouncycastle.asn1.ASN1Encoding;
-import org.bouncycastle.asn1.cmp.*;
+import org.bouncycastle.asn1.cmp.CMPCertificate;
+import org.bouncycastle.asn1.cmp.CertRepMessage;
+import org.bouncycastle.asn1.cmp.CertResponse;
+import org.bouncycastle.asn1.cmp.CertifiedKeyPair;
+import org.bouncycastle.asn1.cmp.PKIBody;
+import org.bouncycastle.asn1.cmp.PKIMessage;
 import org.bouncycastle.asn1.cms.EnvelopedData;
 import org.bouncycastle.asn1.crmf.CertTemplate;
 import org.bouncycastle.asn1.crmf.CertTemplateBuilder;
@@ -43,6 +55,8 @@ import org.slf4j.LoggerFactory;
 public class CkgOnlineEnrollmentTestcaseBase extends OnlineEnrollmentTestcaseBase {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CkgOnlineEnrollmentTestcaseBase.class);
+
+    public static final String INTERFACE_NAME = "testclient";
 
     protected DataSignVerifier verifier;
 
@@ -57,7 +71,7 @@ public class CkgOnlineEnrollmentTestcaseBase extends OnlineEnrollmentTestcaseBas
         final KeyPair keyPair = ConfigurationFactory.getKeyGenerator().generateKeyPair();
         final SubjectPublicKeyInfo subjectPublicKey =
                 SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded());
-        final byte[] publicKey = new byte[0];
+        final byte[] publicKey = {};
         final CertTemplateBuilder ctb = new CertTemplateBuilder()
                 .setPublicKey(new SubjectPublicKeyInfo(subjectPublicKey.getAlgorithm(), publicKey))
                 .setSubject(new X500Name("CN=Subject"));
@@ -97,8 +111,8 @@ public class CkgOnlineEnrollmentTestcaseBase extends OnlineEnrollmentTestcaseBas
                 PkiMessageGenerator.generateCertConfBody(enrolledCertificate));
 
         // try to use received certificate and key
-        final DataSigner testSigner =
-                new DataSigner(recoveredKey, TestCertUtility.certificateFromCmpCertificate(enrolledCertificate));
+        final DataSigner testSigner = new DataSigner(
+                recoveredKey, TestCertUtility.certificateFromCmpCertificate(enrolledCertificate), INTERFACE_NAME);
         final byte[] msgToSign = "Hello Signer, I am the message".getBytes();
         assertArrayEquals(
                 msgToSign,
@@ -120,6 +134,6 @@ public class CkgOnlineEnrollmentTestcaseBase extends OnlineEnrollmentTestcaseBas
     @Before
     public void setUp() throws Exception {
         verifier = new DataSignVerifier(
-                new SignatureValidationCredentials("credentials/CMP_LRA_DOWNSTREAM_Root.pem", null));
+                new SignatureValidationCredentials("credentials/CMP_LRA_DOWNSTREAM_Root.pem", null), INTERFACE_NAME);
     }
 }

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/TestCentralKeyGenerationWithKeyAgreement.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/TestCentralKeyGenerationWithKeyAgreement.java
@@ -60,7 +60,7 @@ public class TestCentralKeyGenerationWithKeyAgreement extends CkgOnlineEnrollmen
 
     public static final String DEFAULT_KEY_ENCRYPTION = "AES256_WRAP";
     private static final Logger LOGGER = LoggerFactory.getLogger(TestCentralKeyGenerationWithKeyAgreement.class);
-    public static Object[][] inputList = new Object[][] {
+    public static Object[][] inputList = {
         //
         {DEFAULT_KEY_AGREEMENT, DEFAULT_KEY_ENCRYPTION},
         //
@@ -125,39 +125,6 @@ public class TestCentralKeyGenerationWithKeyAgreement extends CkgOnlineEnrollmen
             final String keyEncryptionOID) {
         this.keyAgreementAlg = keyAgreementOID;
         this.keyEncryptionAlg = keyEncryptionOID;
-    }
-
-    @Override
-    @Before
-    public void setUp() throws Exception {
-        super.setUp();
-        eeCredentials = new SignatureBasedProtection(
-                new TrustChainAndPrivateKey("credentials/CMP_EE_Keystore.p12", TestUtils.PASSWORD_AS_CHAR_ARRAY));
-        keyAgreementDecryptor =
-                new CmsDecryptor(eeCredentials.getEndCertificate(), eeCredentials.getPrivateKey(), null);
-        launchCmpCaAndRa(buildSignatureBasedDownstreamConfiguration());
-
-        raCredentials = new TrustChainAndPrivateKey(
-                "credentials/CMP_LRA_DOWNSTREAM_Keystore.p12", TestUtils.PASSWORD_AS_CHAR_ARRAY);
-    }
-
-    /**
-     * Central Key Generation/Using Key Agreement Key Management Technique
-     */
-    @Test
-    public void testCrWithKeyAgreement() throws Exception {
-        executeCrmfCertificateRequestWithoutKey(
-                PKIBody.TYPE_CERT_REQ, PKIBody.TYPE_CERT_REP, eeCredentials, getEeClient(), keyAgreementDecryptor);
-    }
-
-    @Test
-    public void testKurWithKeyAgreement() throws Exception {
-        executeCrmfCertificateRequestWithoutKey(
-                PKIBody.TYPE_KEY_UPDATE_REQ,
-                PKIBody.TYPE_KEY_UPDATE_REP,
-                eeCredentials,
-                getEeClient(),
-                keyAgreementDecryptor);
     }
 
     private Configuration buildSignatureBasedDownstreamConfiguration() throws Exception {
@@ -472,5 +439,39 @@ public class TestCentralKeyGenerationWithKeyAgreement extends CkgOnlineEnrollmen
                 return true;
             }
         };
+    }
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        eeCredentials = new SignatureBasedProtection(
+                new TrustChainAndPrivateKey("credentials/CMP_EE_Keystore.p12", TestUtils.PASSWORD_AS_CHAR_ARRAY),
+                INTERFACE_NAME);
+        keyAgreementDecryptor =
+                new CmsDecryptor(eeCredentials.getEndCertificate(), eeCredentials.getPrivateKey(), null);
+        launchCmpCaAndRa(buildSignatureBasedDownstreamConfiguration());
+
+        raCredentials = new TrustChainAndPrivateKey(
+                "credentials/CMP_LRA_DOWNSTREAM_Keystore.p12", TestUtils.PASSWORD_AS_CHAR_ARRAY);
+    }
+
+    /**
+     * Central Key Generation/Using Key Agreement Key Management Technique
+     */
+    @Test
+    public void testCrWithKeyAgreement() throws Exception {
+        executeCrmfCertificateRequestWithoutKey(
+                PKIBody.TYPE_CERT_REQ, PKIBody.TYPE_CERT_REP, eeCredentials, getEeClient(), keyAgreementDecryptor);
+    }
+
+    @Test
+    public void testKurWithKeyAgreement() throws Exception {
+        executeCrmfCertificateRequestWithoutKey(
+                PKIBody.TYPE_KEY_UPDATE_REQ,
+                PKIBody.TYPE_KEY_UPDATE_REP,
+                eeCredentials,
+                getEeClient(),
+                keyAgreementDecryptor);
     }
 }

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/TestCentralKeyGenerationWithKeyTransport.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/TestCentralKeyGenerationWithKeyTransport.java
@@ -348,7 +348,8 @@ public class TestCentralKeyGenerationWithKeyTransport extends CkgOnlineEnrollmen
     public void setUp() throws Exception {
         super.setUp();
         eeRsaCredentials = new SignatureBasedProtection(
-                new TrustChainAndPrivateKey("credentials/CMP_EE_Keystore_RSA.p12", TestUtils.PASSWORD_AS_CHAR_ARRAY));
+                new TrustChainAndPrivateKey("credentials/CMP_EE_Keystore_RSA.p12", TestUtils.PASSWORD_AS_CHAR_ARRAY),
+                INTERFACE_NAME);
         keyTransportDecryptor =
                 new CmsDecryptor(eeRsaCredentials.getEndCertificate(), eeRsaCredentials.getPrivateKey(), null);
         launchCmpCaAndRa(buildRsaSignatureBasedDownstreamConfiguration());

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/TestCentralKeyGenerationWithPassword.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/TestCentralKeyGenerationWithPassword.java
@@ -59,7 +59,7 @@ public class TestCentralKeyGenerationWithPassword extends CkgOnlineEnrollmentTes
     private static final String DEFAULT_PRF = "SHA224";
     private static final int DEFAULT_ITERATIONCOUNT = 10_000;
     private static final Logger LOGGER = LoggerFactory.getLogger(TestCentralKeyGenerationWithPassword.class);
-    public static Object[][] inputList = new Object[][] {
+    public static Object[][] inputList = {
         //
         {DEFAULT_PRF, DEFAULT_ITERATIONCOUNT, DEFAULT_KEK_ALG},
         //
@@ -135,26 +135,8 @@ public class TestCentralKeyGenerationWithPassword extends CkgOnlineEnrollmentTes
         final SignatureValidationCredentials enrollmentTrust =
                 new SignatureValidationCredentials("credentials/ENROLL_Root.pem", null);
 
-        final Configuration config = buildSimpleRaConfiguration(
+        return buildSimpleRaConfiguration(
                 sharedSecret, downstreamTrust, upstreamCredentials, upstreamTrust, enrollmentTrust);
-        return config;
-    }
-
-    /**
-     * Central Key Generation/Using Password-Based Key Management Technique
-     *
-     * @throws Exception
-     */
-    @Test
-    public void testCrWithPassword() throws Exception {
-        final ProtectionProvider macBasedProvider = new PasswordBasedMacProtection(sharedSecret);
-
-        executeCrmfCertificateRequestWithoutKey(
-                PKIBody.TYPE_CERT_REQ,
-                PKIBody.TYPE_CERT_REP,
-                macBasedProvider,
-                getEeClient(),
-                new CmsDecryptor(null, null, "theSecret".toCharArray()));
     }
 
     protected Configuration buildSimpleRaConfiguration(
@@ -436,5 +418,22 @@ public class TestCentralKeyGenerationWithPassword extends CkgOnlineEnrollmentTes
                 return true;
             }
         };
+    }
+
+    /**
+     * Central Key Generation/Using Password-Based Key Management Technique
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCrWithPassword() throws Exception {
+        final ProtectionProvider macBasedProvider = new PasswordBasedMacProtection(sharedSecret, INTERFACE_NAME);
+
+        executeCrmfCertificateRequestWithoutKey(
+                PKIBody.TYPE_CERT_REQ,
+                PKIBody.TYPE_CERT_REP,
+                macBasedProvider,
+                getEeClient(),
+                new CmsDecryptor(null, null, "theSecret".toCharArray()));
     }
 }

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/framework/CmpCaMock.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/framework/CmpCaMock.java
@@ -74,6 +74,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CmpCaMock implements CmpRaComponent.UpstreamExchange {
 
+    private static final String INTERFACE_NAME = "CA Mock";
     private static final Logger LOGGER = LoggerFactory.getLogger(CmpCaMock.class);
     private static final JcaX509ContentVerifierProviderBuilder X509_CVPB =
             new JcaX509ContentVerifierProviderBuilder().setProvider(CertUtility.getBouncyCastleProvider());
@@ -90,7 +91,7 @@ public class CmpCaMock implements CmpRaComponent.UpstreamExchange {
         this.enrollmentCredentials =
                 new TrustChainAndPrivateKey(enrollmentCredentials, TestUtils.PASSWORD_AS_CHAR_ARRAY);
         caProtectionProvider = new SignatureBasedProtection(
-                new TrustChainAndPrivateKey(protectionCredentials, TestUtils.PASSWORD_AS_CHAR_ARRAY));
+                new TrustChainAndPrivateKey(protectionCredentials, TestUtils.PASSWORD_AS_CHAR_ARRAY), INTERFACE_NAME);
     }
 
     private CMPCertificate createCertificate(

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/framework/ConfigurationFactory.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/framework/ConfigurationFactory.java
@@ -70,6 +70,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ConfigurationFactory {
 
+    private static final String INTERFACE_NAME = "testclient";
     private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationFactory.class);
     public static ProtectionProvider eeSignaturebasedProtectionProvider;
     public static ProtectionProvider eePbmac1ProtectionProvider;
@@ -705,7 +706,7 @@ public class ConfigurationFactory {
             throws InvalidKeyException, NoSuchAlgorithmException, InvalidKeySpecException {
         if (eePasswordbasedProtectionProvider == null) {
             eePasswordbasedProtectionProvider =
-                    ProtectionProviderFactory.createProtectionProvider(getEeSharedSecretCredentials());
+                    ProtectionProviderFactory.createProtectionProvider(getEeSharedSecretCredentials(), INTERFACE_NAME);
         }
         return eePasswordbasedProtectionProvider;
     }
@@ -713,8 +714,8 @@ public class ConfigurationFactory {
     public static ProtectionProvider getEePbmac1ProtectionProvider()
             throws InvalidKeyException, NoSuchAlgorithmException, InvalidKeySpecException {
         if (eePbmac1ProtectionProvider == null) {
-            eePbmac1ProtectionProvider =
-                    ProtectionProviderFactory.createProtectionProvider(new SharedSecret("PBMAC1", TestUtils.PASSWORD));
+            eePbmac1ProtectionProvider = ProtectionProviderFactory.createProtectionProvider(
+                    new SharedSecret("PBMAC1", TestUtils.PASSWORD), INTERFACE_NAME);
         }
         return eePbmac1ProtectionProvider;
     }
@@ -738,8 +739,8 @@ public class ConfigurationFactory {
 
     public static ProtectionProvider getEeSignaturebasedProtectionProvider() throws Exception {
         if (eeSignaturebasedProtectionProvider == null) {
-            eeSignaturebasedProtectionProvider =
-                    ProtectionProviderFactory.createProtectionProvider(getEeSignaturebasedCredentials());
+            eeSignaturebasedProtectionProvider = ProtectionProviderFactory.createProtectionProvider(
+                    getEeSignaturebasedCredentials(), INTERFACE_NAME);
         }
         return eeSignaturebasedProtectionProvider;
     }


### PR DESCRIPTION
## Description
Log access to configuration as much as possible

## Related Issue

https://github.com/siemens/cmp-ra-component/issues/92

## Motivation and Context

If the configuration methods return non-compliant values or generate exceptions the overall behavior of CmpRaComponent is sometimes strange.

## How Has This Been Tested?

Run Unit-Test with logging enabled.

## Screenshots
