### PR TITLE
Use same credentials for MAC based protection at Downstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,3 +143,8 @@ fix: handling of NestedEndpointContext.isIncomingRecipientValid
 ### 4.1.4 (Jul 23 2024)
 
 fix: again fix protection of NESTED responses
+
+### 4.2.0 (Sep 10 2024)
+
+feat: Use same credentials for MAC based protection at Downstream
+

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<groupId>com.siemens.pki</groupId>
 	<artifactId>CmpRaComponent</artifactId>
 	<packaging>jar</packaging>
-	<version>4.1.4</version>
+	<version>4.2.0</version>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<parent.basedir>.</parent.basedir>

--- a/src/main/java/com/siemens/pki/cmpclientcomponent/main/ClientRequestHandler.java
+++ b/src/main/java/com/siemens/pki/cmpclientcomponent/main/ClientRequestHandler.java
@@ -17,6 +17,8 @@
  */
 package com.siemens.pki.cmpclientcomponent.main;
 
+import static com.siemens.pki.cmpracomponent.util.NullUtil.ifNotNull;
+
 import com.siemens.pki.cmpclientcomponent.configuration.ClientContext;
 import com.siemens.pki.cmpracomponent.configuration.CmpMessageInterface;
 import com.siemens.pki.cmpracomponent.configuration.NestedEndpointContext;
@@ -36,6 +38,9 @@ import com.siemens.pki.cmpracomponent.msgvalidation.ValidatorIF;
 import com.siemens.pki.cmpracomponent.util.ConfigLogger;
 import com.siemens.pki.cmpracomponent.util.FileTracer;
 import com.siemens.pki.cmpracomponent.util.MessageDumper;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.Objects;
 import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.DERNull;
 import org.bouncycastle.asn1.DEROctetString;
@@ -55,12 +60,6 @@ import org.bouncycastle.asn1.cmp.PollRepContent;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.security.GeneralSecurityException;
-import java.util.ArrayList;
-import java.util.Objects;
-
-import static com.siemens.pki.cmpracomponent.util.NullUtil.ifNotNull;
 
 /**
  *

--- a/src/main/java/com/siemens/pki/cmpclientcomponent/main/ClientRequestHandler.java
+++ b/src/main/java/com/siemens/pki/cmpclientcomponent/main/ClientRequestHandler.java
@@ -17,8 +17,6 @@
  */
 package com.siemens.pki.cmpclientcomponent.main;
 
-import static com.siemens.pki.cmpracomponent.util.NullUtil.ifNotNull;
-
 import com.siemens.pki.cmpclientcomponent.configuration.ClientContext;
 import com.siemens.pki.cmpracomponent.configuration.CmpMessageInterface;
 import com.siemens.pki.cmpracomponent.configuration.NestedEndpointContext;
@@ -38,9 +36,6 @@ import com.siemens.pki.cmpracomponent.msgvalidation.ValidatorIF;
 import com.siemens.pki.cmpracomponent.util.ConfigLogger;
 import com.siemens.pki.cmpracomponent.util.FileTracer;
 import com.siemens.pki.cmpracomponent.util.MessageDumper;
-import java.security.GeneralSecurityException;
-import java.util.ArrayList;
-import java.util.Objects;
 import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.DERNull;
 import org.bouncycastle.asn1.DEROctetString;
@@ -60,6 +55,12 @@ import org.bouncycastle.asn1.cmp.PollRepContent;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.Objects;
+
+import static com.siemens.pki.cmpracomponent.util.NullUtil.ifNotNull;
 
 /**
  *
@@ -83,7 +84,7 @@ class ClientRequestHandler {
         public ValidatorAndProtector(NestedEndpointContext nestedEndpoint)
                 throws GeneralSecurityException, CmpProcessingException {
             headerValidator = new MessageHeaderValidator(NESTED_INTERFACE_NAME);
-            outputProtection = new MsgOutputProtector(nestedEndpoint, NESTED_INTERFACE_NAME);
+            outputProtection = new MsgOutputProtector(nestedEndpoint, NESTED_INTERFACE_NAME, null);
             this.inputVerification = ConfigLogger.logOptional(
                     NESTED_INTERFACE_NAME,
                     "NestedEndpointContext.getInputVerification()",

--- a/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/TrustCredentialAdapter.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/TrustCredentialAdapter.java
@@ -19,6 +19,9 @@ package com.siemens.pki.cmpracomponent.cryptoservices;
 
 import com.siemens.pki.cmpracomponent.configuration.VerificationContext;
 import com.siemens.pki.cmpracomponent.util.ConfigLogger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.net.URI;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
@@ -42,8 +45,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Class for building a certification chain for given certificate and verifying

--- a/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/TrustCredentialAdapter.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/TrustCredentialAdapter.java
@@ -19,9 +19,6 @@ package com.siemens.pki.cmpracomponent.cryptoservices;
 
 import com.siemens.pki.cmpracomponent.configuration.VerificationContext;
 import com.siemens.pki.cmpracomponent.util.ConfigLogger;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.URI;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
@@ -45,6 +42,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class for building a certification chain for given certificate and verifying
@@ -129,9 +128,9 @@ public class TrustCredentialAdapter {
             final boolean[] leafKeyUsage = cert.getKeyUsage();
             if (leafKeyUsage != null && !leafKeyUsage[0] // digitalSignature
                     || !ConfigLogger.log(
-                            interfaceName,
-                            "VerificationContext.isLeafCertAcceptable(X509Certificate)",
-                            () -> config.isLeafCertAcceptable(cert))) {
+                    interfaceName,
+                    "VerificationContext.isLeafCertAcceptable(X509Certificate)",
+                    () -> config.isLeafCertAcceptable(cert))) {
                 return null;
             }
             // initial state

--- a/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/TrustCredentialAdapter.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/cryptoservices/TrustCredentialAdapter.java
@@ -128,9 +128,9 @@ public class TrustCredentialAdapter {
             final boolean[] leafKeyUsage = cert.getKeyUsage();
             if (leafKeyUsage != null && !leafKeyUsage[0] // digitalSignature
                     || !ConfigLogger.log(
-                    interfaceName,
-                    "VerificationContext.isLeafCertAcceptable(X509Certificate)",
-                    () -> config.isLeafCertAcceptable(cert))) {
+                            interfaceName,
+                            "VerificationContext.isLeafCertAcceptable(X509Certificate)",
+                            () -> config.isLeafCertAcceptable(cert))) {
                 return null;
             }
             // initial state

--- a/src/main/java/com/siemens/pki/cmpracomponent/msggeneration/MsgOutputProtector.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msggeneration/MsgOutputProtector.java
@@ -17,6 +17,9 @@
  */
 package com.siemens.pki.cmpracomponent.msggeneration;
 
+import static com.siemens.pki.cmpracomponent.util.NullUtil.defaultIfNull;
+import static com.siemens.pki.cmpracomponent.util.NullUtil.ifNotNull;
+
 import com.siemens.pki.cmpracomponent.configuration.CmpMessageInterface;
 import com.siemens.pki.cmpracomponent.configuration.CmpMessageInterface.ReprotectMode;
 import com.siemens.pki.cmpracomponent.configuration.CredentialContext;
@@ -28,15 +31,6 @@ import com.siemens.pki.cmpracomponent.persistency.PersistencyContext;
 import com.siemens.pki.cmpracomponent.protection.ProtectionProvider;
 import com.siemens.pki.cmpracomponent.protection.ProtectionProviderFactory;
 import com.siemens.pki.cmpracomponent.util.ConfigLogger;
-import org.bouncycastle.asn1.cmp.CMPCertificate;
-import org.bouncycastle.asn1.cmp.PKIBody;
-import org.bouncycastle.asn1.cmp.PKIFailureInfo;
-import org.bouncycastle.asn1.cmp.PKIMessage;
-import org.bouncycastle.asn1.x500.X500Name;
-import org.bouncycastle.asn1.x509.GeneralName;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
@@ -45,9 +39,14 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
-
-import static com.siemens.pki.cmpracomponent.util.NullUtil.defaultIfNull;
-import static com.siemens.pki.cmpracomponent.util.NullUtil.ifNotNull;
+import org.bouncycastle.asn1.cmp.CMPCertificate;
+import org.bouncycastle.asn1.cmp.PKIBody;
+import org.bouncycastle.asn1.cmp.PKIFailureInfo;
+import org.bouncycastle.asn1.cmp.PKIMessage;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * the {@link MsgOutputProtector} sets the right protection for outgoing
@@ -116,7 +115,8 @@ public class MsgOutputProtector {
      * @throws CmpProcessingException   in case of inconsistent configuration
      * @throws GeneralSecurityException in case of broken configuration
      */
-    public MsgOutputProtector(final NestedEndpointContext config, final String interfaceName, final CredentialContext credentialContext)
+    public MsgOutputProtector(
+            final NestedEndpointContext config, final String interfaceName, final CredentialContext credentialContext)
             throws CmpProcessingException, GeneralSecurityException {
         this.persistencyContext = null;
         suppressRedundantExtraCerts = false;

--- a/src/main/java/com/siemens/pki/cmpracomponent/msggeneration/MsgOutputProtector.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msggeneration/MsgOutputProtector.java
@@ -86,15 +86,16 @@ public class MsgOutputProtector {
                 interfaceName,
                 "CmpMessageInterface.getSuppressRedundantExtraCerts()",
                 config::getSuppressRedundantExtraCerts);
-        reprotectMode = ConfigLogger.log(interfaceName, "CmpMessageInterface.getReprotectMode()", config::getReprotectMode);
+        reprotectMode =
+                ConfigLogger.log(interfaceName, "CmpMessageInterface.getReprotectMode()", config::getReprotectMode);
         recipient = ifNotNull(
                 ConfigLogger.logOptional(interfaceName, "CmpMessageInterface.getRecipient()", config::getRecipient),
                 rec -> new GeneralName(new X500Name(rec)));
-        final CredentialContext verificationCredentials = ifNotNull(messageContext, MessageContext::getCredentialContext);
+        final CredentialContext verificationCredentials =
+                ifNotNull(messageContext, MessageContext::getCredentialContext);
         if (verificationCredentials instanceof SharedSecretCredentialContext) {
             protectionCredentials = verificationCredentials;
-        }
-        else {
+        } else {
             protectionCredentials = ConfigLogger.logOptional(
                     interfaceName, "CmpMessageInterface.getOutputCredentials()", config::getOutputCredentials);
             if (reprotectMode == ReprotectMode.reprotect && protectionCredentials == null) {
@@ -104,7 +105,7 @@ public class MsgOutputProtector {
                         "reprotectMode is reprotect, but no output credentials are given");
             }
         }
-        protector = ProtectionProviderFactory.createProtectionProvider(outputCredentials, interfaceName);
+        protector = ProtectionProviderFactory.createProtectionProvider(protectionCredentials, interfaceName);
     }
 
     /**

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/CmpRaUpstream.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/CmpRaUpstream.java
@@ -132,9 +132,8 @@ class CmpRaUpstream implements RaUpstream {
                 // never re-protect a KUR
                 sentMessage = in;
             } else {
-                final MsgOutputProtector outputProtector =
-                        new MsgOutputProtector(upstreamConfiguration, INTERFACE_NAME,
-                                new MessageContext(persistencyContext, null));
+                final MsgOutputProtector outputProtector = new MsgOutputProtector(
+                        upstreamConfiguration, INTERFACE_NAME, new MessageContext(persistencyContext, null));
                 sentMessage = outputProtector.protectOutgoingMessage(in, null);
             }
             final NestedEndpointContext nestedEndpointContext = ConfigLogger.logOptional(

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/CmpRaUpstream.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/CmpRaUpstream.java
@@ -26,6 +26,7 @@ import com.siemens.pki.cmpracomponent.msgvalidation.BaseCmpException;
 import com.siemens.pki.cmpracomponent.msgvalidation.CmpProcessingException;
 import com.siemens.pki.cmpracomponent.msgvalidation.CmpValidationException;
 import com.siemens.pki.cmpracomponent.msgvalidation.InputValidator;
+import com.siemens.pki.cmpracomponent.msgvalidation.MessageContext;
 import com.siemens.pki.cmpracomponent.msgvalidation.MessageHeaderValidator;
 import com.siemens.pki.cmpracomponent.msgvalidation.ProtectionValidator;
 import com.siemens.pki.cmpracomponent.persistency.PersistencyContext;
@@ -52,8 +53,6 @@ import org.slf4j.LoggerFactory;
 class CmpRaUpstream implements RaUpstream {
 
     private static final String INTERFACE_NAME = "CMP upstream";
-
-    private static final String NESTED_INTERFACE_NAME = "nested " + INTERFACE_NAME;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CmpRaUpstream.class);
 
@@ -132,7 +131,8 @@ class CmpRaUpstream implements RaUpstream {
                 sentMessage = in;
             } else {
                 final MsgOutputProtector outputProtector =
-                        new MsgOutputProtector(upstreamConfiguration, INTERFACE_NAME, persistencyContext);
+                        new MsgOutputProtector(upstreamConfiguration, INTERFACE_NAME,
+                                new MessageContext(persistencyContext, null));
                 sentMessage = outputProtector.protectOutgoingMessage(in, null);
             }
             final NestedEndpointContext nestedEndpointContext = ConfigLogger.logOptional(

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/CmpRaUpstream.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/CmpRaUpstream.java
@@ -54,6 +54,8 @@ class CmpRaUpstream implements RaUpstream {
 
     private static final String INTERFACE_NAME = "CMP upstream";
 
+    private static final String NESTED_INTERFACE_NAME = "nested " + INTERFACE_NAME;
+
     private static final Logger LOGGER = LoggerFactory.getLogger(CmpRaUpstream.class);
 
     private static final Collection<Integer> supportedMessageTypes = new HashSet<>(Arrays.asList(
@@ -141,7 +143,7 @@ class CmpRaUpstream implements RaUpstream {
                     upstreamConfiguration::getNestedEndpointContext);
             if (nestedEndpointContext != null) {
                 final MsgOutputProtector nestedProtector =
-                        new MsgOutputProtector(nestedEndpointContext, "NESTED CMP upstream");
+                        new MsgOutputProtector(nestedEndpointContext, "NESTED CMP upstream", null);
                 // wrap into nested message
                 sentMessage = nestedProtector.protectOutgoingMessage(
                         new PKIMessage(

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/RaDownstream.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/RaDownstream.java
@@ -17,12 +17,12 @@
  */
 package com.siemens.pki.cmpracomponent.msgprocessing;
 
-import static com.siemens.pki.cmpracomponent.util.NullUtil.ifNotNull;
-
+import com.siemens.pki.cmpracomponent.configuration.CheckAndModifyResult;
 import com.siemens.pki.cmpracomponent.configuration.CheckAndModifyResult;
 import com.siemens.pki.cmpracomponent.configuration.CkgContext;
 import com.siemens.pki.cmpracomponent.configuration.CmpMessageInterface;
 import com.siemens.pki.cmpracomponent.configuration.Configuration;
+import com.siemens.pki.cmpracomponent.configuration.CredentialContext;
 import com.siemens.pki.cmpracomponent.configuration.InventoryInterface;
 import com.siemens.pki.cmpracomponent.configuration.NestedEndpointContext;
 import com.siemens.pki.cmpracomponent.configuration.SignatureCredentialContext;
@@ -104,6 +104,25 @@ import org.bouncycastle.pkcs.PKCSException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.siemens.pki.cmpracomponent.util.NullUtil.ifNotNull;
+
 /**
  * representation of a downstream interface of a RA
  */
@@ -135,8 +154,6 @@ class RaDownstream {
     private final RaUpstream upstreamHandler;
 
     private final PersistencyContextManager persistencyContextManager;
-
-    private boolean macBasedProtection;
 
     /**
      * @param persistencyContextManager persistency interface

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/RaDownstream.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/RaDownstream.java
@@ -325,21 +325,21 @@ class RaDownstream {
                             certTemplateWithPublicKey,
                             controlsInRequest,
                             ConfigLogger.log(
-                                    INTERFACE_NAME,
-                                    "Configuration.getForceRaVerifyOnUpstream",
-                                    config::getForceRaVerifyOnUpstream,
-                                    persistencyContext.getCertProfile(),
-                                    requestBodyType)
+                                            INTERFACE_NAME,
+                                            "Configuration.getForceRaVerifyOnUpstream",
+                                            config::getForceRaVerifyOnUpstream,
+                                            persistencyContext.getCertProfile(),
+                                            requestBodyType)
                                     ? null
                                     : privateKey));
         }
         final ProofOfPossession popo = certReqMsg.getPop();
         if (ConfigLogger.log(
-                INTERFACE_NAME,
-                "Configuration.getForceRaVerifyOnUpstream",
-                config::getForceRaVerifyOnUpstream,
-                persistencyContext.getCertProfile(),
-                requestBodyType)
+                        INTERFACE_NAME,
+                        "Configuration.getForceRaVerifyOnUpstream",
+                        config::getForceRaVerifyOnUpstream,
+                        persistencyContext.getCertProfile(),
+                        requestBodyType)
                 || popo == null
                 || popo.getType() == ProofOfPossession.TYPE_RA_VERIFIED) {
             // popo invalid or raVerified, regenerate body
@@ -433,7 +433,7 @@ class RaDownstream {
                         break;
                     case PKIBody.TYPE_POLL_REP:
                         retryAfterTime = ((PollRepContent)
-                                responseFromUpstream.getBody().getContent())
+                                        responseFromUpstream.getBody().getContent())
                                 .getCheckAfter(0)
                                 .intPositiveValueExact();
                         break;
@@ -446,7 +446,7 @@ class RaDownstream {
                         ifNotNull(persistencyContext, PersistencyContext::getCertProfile),
                         responseBodyType);
                 PKIMessage protectedResponse = new MsgOutputProtector(
-                        downstreamConfiguration, INTERFACE_NAME, messageContext)
+                                downstreamConfiguration, INTERFACE_NAME, messageContext)
                         .protectOutgoingMessage(
                                 new PKIMessage(
                                         responseFromUpstream.getHeader(),
@@ -463,7 +463,8 @@ class RaDownstream {
                     // no nesting required
                     return protectedResponse;
                 }
-                return new MsgOutputProtector(nestedEndpointContext, NESTED_INTERFACE_NAME, messageContext.getCredentialContext())
+                return new MsgOutputProtector(
+                                nestedEndpointContext, NESTED_INTERFACE_NAME, messageContext.getCredentialContext())
                         .createOutgoingMessage(
                                 PkiMessageGenerator.buildForwardingHeaderProvider(protectedResponse),
                                 new PKIBody(PKIBody.TYPE_NESTED, new PKIMessages(protectedResponse)));
@@ -558,8 +559,8 @@ class RaDownstream {
         final PKIMessage[] responses =
                 Arrays.stream(embeddedMessages).map(this::handleInputMessage).toArray(PKIMessage[]::new);
         // batched responses needs to be wrapped in a new NESTED response
-        MsgOutputProtector nestedOutputProtector = new MsgOutputProtector(nestedEndpointContext, INTERFACE_NAME,
-                credentialContext);
+        MsgOutputProtector nestedOutputProtector =
+                new MsgOutputProtector(nestedEndpointContext, INTERFACE_NAME, credentialContext);
         return nestedOutputProtector.generateAndProtectResponseTo(
                 in, new PKIBody(PKIBody.TYPE_NESTED, new PKIMessages(responses)));
     }
@@ -655,8 +656,7 @@ class RaDownstream {
         return incomingRequest;
     }
 
-    private PKIMessage handleValidatedRequest(
-            final PKIMessage incomingRequest, final MessageContext messageContext)
+    private PKIMessage handleValidatedRequest(final PKIMessage incomingRequest, final MessageContext messageContext)
             throws BaseCmpException, IOException {
         // request pre processing
         // by default there is no pre processing
@@ -687,8 +687,8 @@ class RaDownstream {
             case PKIBody.TYPE_GEN_MSG:
                 // try to handle locally
                 persistencyContext.setRequestType(incomingRequest.getBody().getType());
-                final PKIMessage genmResponse = new ServiceImplementation(config)
-                        .handleValidatedInputMessage(incomingRequest, messageContext);
+                final PKIMessage genmResponse =
+                        new ServiceImplementation(config).handleValidatedInputMessage(incomingRequest, messageContext);
                 if (genmResponse != null) {
                     return genmResponse;
                 }

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/ServiceImplementation.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/ServiceImplementation.java
@@ -239,7 +239,8 @@ class ServiceImplementation {
             final SupportMessageHandlerInterface messageHandler = ConfigLogger.logOptional(
                     INTERFACE_NAME,
                     "com.siemens.pki.cmpracomponent.configuration.Configuration.getSupportMessageHandler(String, String)",
-                    () -> config.getSupportMessageHandler(messageContext.getPersistencyContext().getCertProfile(), infoType.getId()));
+                    () -> config.getSupportMessageHandler(
+                            messageContext.getPersistencyContext().getCertProfile(), infoType.getId()));
             if (messageHandler == null) {
                 return null;
             }

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/ServiceImplementation.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/ServiceImplementation.java
@@ -30,6 +30,7 @@ import com.siemens.pki.cmpracomponent.cryptoservices.CertUtility;
 import com.siemens.pki.cmpracomponent.msggeneration.MsgOutputProtector;
 import com.siemens.pki.cmpracomponent.msgvalidation.BaseCmpException;
 import com.siemens.pki.cmpracomponent.msgvalidation.CmpProcessingException;
+import com.siemens.pki.cmpracomponent.msgvalidation.MessageContext;
 import com.siemens.pki.cmpracomponent.persistency.PersistencyContext;
 import com.siemens.pki.cmpracomponent.util.ConfigLogger;
 import java.io.IOException;
@@ -229,7 +230,7 @@ class ServiceImplementation {
                 new GenRepContent(new InfoTypeAndValue(CMPObjectIdentifiers.id_it_rootCaKeyUpdate)));
     }
 
-    protected PKIMessage handleValidatedInputMessage(final PKIMessage msg, final PersistencyContext persistencyContext)
+    protected PKIMessage handleValidatedInputMessage(final PKIMessage msg, final MessageContext messageContext)
             throws BaseCmpException {
         try {
             final InfoTypeAndValue itav = ((GenMsgContent) msg.getBody().getContent()).toInfoTypeAndValueArray()[0];
@@ -238,7 +239,7 @@ class ServiceImplementation {
             final SupportMessageHandlerInterface messageHandler = ConfigLogger.logOptional(
                     INTERFACE_NAME,
                     "com.siemens.pki.cmpracomponent.configuration.Configuration.getSupportMessageHandler(String, String)",
-                    () -> config.getSupportMessageHandler(persistencyContext.getCertProfile(), infoType.getId()));
+                    () -> config.getSupportMessageHandler(messageContext.getPersistencyContext().getCertProfile(), infoType.getId()));
             if (messageHandler == null) {
                 return null;
             }
@@ -264,10 +265,10 @@ class ServiceImplementation {
                             INTERFACE_NAME,
                             "Configuration.getDownstreamConfiguration",
                             config::getDownstreamConfiguration,
-                            ifNotNull(persistencyContext, PersistencyContext::getCertProfile),
+                            ifNotNull(messageContext.getPersistencyContext(), PersistencyContext::getCertProfile),
                             body.getType()),
                     INTERFACE_NAME,
-                    persistencyContext);
+                    messageContext);
             return protector.generateAndProtectResponseTo(msg, body);
         } catch (final BaseCmpException ex) {
             throw ex;

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/InputValidator.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/InputValidator.java
@@ -18,6 +18,7 @@
 package com.siemens.pki.cmpracomponent.msgvalidation;
 
 import com.siemens.pki.cmpracomponent.configuration.CmpMessageInterface;
+import com.siemens.pki.cmpracomponent.configuration.CredentialContext;
 import com.siemens.pki.cmpracomponent.persistency.PersistencyContext;
 import com.siemens.pki.cmpracomponent.util.ConfigLogger;
 import com.siemens.pki.cmpracomponent.util.MessageDumper;
@@ -30,7 +31,7 @@ import org.bouncycastle.asn1.cmp.PKIMessage;
 /**
  * validator for an incoming message
  */
-public class InputValidator implements ValidatorIF<Void> {
+public class InputValidator implements ValidatorIF<MessageContext> {
 
     private final Collection<Integer> supportedMessageTypes;
     private final String interfaceName;
@@ -68,11 +69,11 @@ public class InputValidator implements ValidatorIF<Void> {
      * message types
      *
      * @param in message to validate
-     * @return nothing
+     * @return a message context
      * @throws CmpProcessingException if validation failed
      */
     @Override
-    public Void validate(final PKIMessage in) throws BaseCmpException {
+    public MessageContext validate(final PKIMessage in) throws BaseCmpException {
         if (!supportedMessageTypes.contains(in.getBody().getType())) {
             throw new CmpValidationException(
                     interfaceName,
@@ -97,8 +98,8 @@ public class InputValidator implements ValidatorIF<Void> {
                             interfaceName,
                             "CmpMessageInterface.getInputVerification()",
                             cmpInterface::getInputVerification));
-            protectionValidator.validate(in);
-            return null;
+            CredentialContext protectionCredentials = protectionValidator.validate(in);
+            return new MessageContext(persistencyContext, protectionCredentials);
         } catch (final BaseCmpException ce) {
             throw ce;
         } catch (final Exception e) {

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/MacValidator.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/MacValidator.java
@@ -17,6 +17,7 @@
  */
 package com.siemens.pki.cmpracomponent.msgvalidation;
 
+import com.siemens.pki.cmpracomponent.configuration.CredentialContext;
 import com.siemens.pki.cmpracomponent.configuration.VerificationContext;
 import com.siemens.pki.cmpracomponent.util.ConfigLogger;
 import com.siemens.pki.cmpracomponent.util.NullUtil;
@@ -27,7 +28,7 @@ import org.bouncycastle.asn1.cmp.PKIHeader;
 /**
  * base class for all MAC based validators
  */
-public abstract class MacValidator implements ValidatorIF<Void> {
+public abstract class MacValidator implements ValidatorIF<CredentialContext> {
 
     protected final VerificationContext config;
     private final String interfaceName;

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/MessageContext.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/MessageContext.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024 Siemens AG
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.siemens.pki.cmpracomponent.msgvalidation;
+
+import com.siemens.pki.cmpracomponent.configuration.CredentialContext;
+import com.siemens.pki.cmpracomponent.persistency.PersistencyContext;
+
+/**
+ * Container class to store @link{PersistencyContext} and @link{CredentialContext} of a PKI message
+ */
+public class MessageContext {
+
+    final PersistencyContext persistencyContext;
+    final CredentialContext credentialContext;
+
+    /**
+     * Class constructor
+     * @param persistency   a persistency context
+     * @param credentials   a credential context
+     */
+    public MessageContext(PersistencyContext persistency, CredentialContext credentials) {
+        persistencyContext = persistency;
+        credentialContext = credentials;
+    }
+
+    /**
+     * provide a persistency context
+     * @return a persistency context
+     */
+    public PersistencyContext getPersistencyContext() {
+        return persistencyContext;
+    }
+
+    /**
+     * provide a credential context configuration usable for message protection
+     * @return  a credential context
+     */
+    public CredentialContext getCredentialContext() {
+        return credentialContext;
+    }
+}

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/PBMAC1ProtectionValidator.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/PBMAC1ProtectionValidator.java
@@ -22,7 +22,7 @@ import com.siemens.pki.cmpracomponent.configuration.VerificationContext;
 import com.siemens.pki.cmpracomponent.cryptoservices.AlgorithmHelper;
 import com.siemens.pki.cmpracomponent.cryptoservices.WrappedMac;
 import com.siemens.pki.cmpracomponent.cryptoservices.WrappedMacFactory;
-import com.siemens.pki.cmpracomponent.protection.SharedSecretCredentials;
+import com.siemens.pki.cmpracomponent.protection.OutputSharedSecretCredentials;
 import java.util.Arrays;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
@@ -83,7 +83,7 @@ public class PBMAC1ProtectionValidator extends MacValidator {
                 throw new CmpValidationException(
                         getInterfaceName(), PKIFailureInfo.badMessageCheck, "PBMAC1 protection check failed");
             }
-            return new SharedSecretCredentials(
+            return new OutputSharedSecretCredentials(
                     params,
                     pbmac1Params.getMessageAuthScheme().getAlgorithm().getId(),
                     header.getSenderKID().getOctets(),

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/PBMAC1ProtectionValidator.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/PBMAC1ProtectionValidator.java
@@ -22,12 +22,11 @@ import com.siemens.pki.cmpracomponent.configuration.VerificationContext;
 import com.siemens.pki.cmpracomponent.cryptoservices.AlgorithmHelper;
 import com.siemens.pki.cmpracomponent.cryptoservices.WrappedMac;
 import com.siemens.pki.cmpracomponent.cryptoservices.WrappedMacFactory;
+import com.siemens.pki.cmpracomponent.protection.SharedSecretCredentials;
 import java.util.Arrays;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
-
-import com.siemens.pki.cmpracomponent.protection.SharedSecretCredentials;
 import org.bouncycastle.asn1.ASN1Encoding;
 import org.bouncycastle.asn1.cmp.PKIFailureInfo;
 import org.bouncycastle.asn1.cmp.PKIHeader;
@@ -84,7 +83,8 @@ public class PBMAC1ProtectionValidator extends MacValidator {
                 throw new CmpValidationException(
                         getInterfaceName(), PKIFailureInfo.badMessageCheck, "PBMAC1 protection check failed");
             }
-            return new SharedSecretCredentials(params,
+            return new SharedSecretCredentials(
+                    params,
                     pbmac1Params.getMessageAuthScheme().getAlgorithm().getId(),
                     header.getSenderKID().getOctets(),
                     passwordAsBytes);

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/PBMAC1ProtectionValidator.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/PBMAC1ProtectionValidator.java
@@ -17,6 +17,7 @@
  */
 package com.siemens.pki.cmpracomponent.msgvalidation;
 
+import com.siemens.pki.cmpracomponent.configuration.CredentialContext;
 import com.siemens.pki.cmpracomponent.configuration.VerificationContext;
 import com.siemens.pki.cmpracomponent.cryptoservices.AlgorithmHelper;
 import com.siemens.pki.cmpracomponent.cryptoservices.WrappedMac;
@@ -25,6 +26,8 @@ import java.util.Arrays;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
+
+import com.siemens.pki.cmpracomponent.protection.SharedSecretCredentials;
 import org.bouncycastle.asn1.ASN1Encoding;
 import org.bouncycastle.asn1.cmp.PKIFailureInfo;
 import org.bouncycastle.asn1.cmp.PKIHeader;
@@ -50,7 +53,7 @@ public class PBMAC1ProtectionValidator extends MacValidator {
     }
 
     @Override
-    public Void validate(final PKIMessage message) throws BaseCmpException {
+    public CredentialContext validate(final PKIMessage message) throws BaseCmpException {
         try {
             final PKIHeader header = message.getHeader();
             final byte[] passwordAsBytes = getSharedSecret(header);
@@ -81,12 +84,15 @@ public class PBMAC1ProtectionValidator extends MacValidator {
                 throw new CmpValidationException(
                         getInterfaceName(), PKIFailureInfo.badMessageCheck, "PBMAC1 protection check failed");
             }
+            return new SharedSecretCredentials(params,
+                    pbmac1Params.getMessageAuthScheme().getAlgorithm().getId(),
+                    header.getSenderKID().getOctets(),
+                    passwordAsBytes);
         } catch (final BaseCmpException cex) {
             throw cex;
         } catch (final Exception ex) {
             throw new CmpProcessingException(
                     getInterfaceName(), PKIFailureInfo.badMessageCheck, ex.getLocalizedMessage());
         }
-        return null;
     }
 }

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/PasswordBasedMacValidator.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/PasswordBasedMacValidator.java
@@ -20,12 +20,11 @@ package com.siemens.pki.cmpracomponent.msgvalidation;
 import com.siemens.pki.cmpracomponent.configuration.CredentialContext;
 import com.siemens.pki.cmpracomponent.configuration.VerificationContext;
 import com.siemens.pki.cmpracomponent.cryptoservices.AlgorithmHelper;
+import com.siemens.pki.cmpracomponent.protection.SharedSecretCredentials;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-
-import com.siemens.pki.cmpracomponent.protection.SharedSecretCredentials;
 import org.bouncycastle.asn1.ASN1Encoding;
 import org.bouncycastle.asn1.cmp.PBMParameter;
 import org.bouncycastle.asn1.cmp.PKIFailureInfo;
@@ -82,9 +81,8 @@ public class PasswordBasedMacValidator extends MacValidator {
                 throw new CmpValidationException(
                         getInterfaceName(), PKIFailureInfo.badMessageCheck, "PasswordBasedMac protection check failed");
             }
-            return new SharedSecretCredentials(pbmParameter,
-                    header.getSenderKID().getOctets(),
-                    passwordAsBytes);
+            return new SharedSecretCredentials(
+                    pbmParameter, header.getSenderKID().getOctets(), passwordAsBytes);
         } catch (final BaseCmpException cex) {
             throw cex;
         } catch (final Exception ex) {

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/PasswordBasedMacValidator.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/PasswordBasedMacValidator.java
@@ -17,12 +17,15 @@
  */
 package com.siemens.pki.cmpracomponent.msgvalidation;
 
+import com.siemens.pki.cmpracomponent.configuration.CredentialContext;
 import com.siemens.pki.cmpracomponent.configuration.VerificationContext;
 import com.siemens.pki.cmpracomponent.cryptoservices.AlgorithmHelper;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
+
+import com.siemens.pki.cmpracomponent.protection.SharedSecretCredentials;
 import org.bouncycastle.asn1.ASN1Encoding;
 import org.bouncycastle.asn1.cmp.PBMParameter;
 import org.bouncycastle.asn1.cmp.PKIFailureInfo;
@@ -48,7 +51,7 @@ public class PasswordBasedMacValidator extends MacValidator {
     }
 
     @Override
-    public Void validate(final PKIMessage message) throws BaseCmpException {
+    public CredentialContext validate(final PKIMessage message) throws BaseCmpException {
         try {
             final PKIHeader header = message.getHeader();
             // Construct the base key according to rfc4210, section 5.1.3.1
@@ -79,12 +82,14 @@ public class PasswordBasedMacValidator extends MacValidator {
                 throw new CmpValidationException(
                         getInterfaceName(), PKIFailureInfo.badMessageCheck, "PasswordBasedMac protection check failed");
             }
+            return new SharedSecretCredentials(pbmParameter,
+                    header.getSenderKID().getOctets(),
+                    passwordAsBytes);
         } catch (final BaseCmpException cex) {
             throw cex;
         } catch (final Exception ex) {
             throw new CmpProcessingException(
                     getInterfaceName(), PKIFailureInfo.badMessageCheck, ex.getLocalizedMessage());
         }
-        return null;
     }
 }

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/PasswordBasedMacValidator.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/PasswordBasedMacValidator.java
@@ -20,7 +20,7 @@ package com.siemens.pki.cmpracomponent.msgvalidation;
 import com.siemens.pki.cmpracomponent.configuration.CredentialContext;
 import com.siemens.pki.cmpracomponent.configuration.VerificationContext;
 import com.siemens.pki.cmpracomponent.cryptoservices.AlgorithmHelper;
-import com.siemens.pki.cmpracomponent.protection.SharedSecretCredentials;
+import com.siemens.pki.cmpracomponent.protection.OutputSharedSecretCredentials;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import javax.crypto.Mac;
@@ -81,7 +81,7 @@ public class PasswordBasedMacValidator extends MacValidator {
                 throw new CmpValidationException(
                         getInterfaceName(), PKIFailureInfo.badMessageCheck, "PasswordBasedMac protection check failed");
             }
-            return new SharedSecretCredentials(
+            return new OutputSharedSecretCredentials(
                     pbmParameter, header.getSenderKID().getOctets(), passwordAsBytes);
         } catch (final BaseCmpException cex) {
             throw cex;

--- a/src/main/java/com/siemens/pki/cmpracomponent/protection/OutputSharedSecretCredentials.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/protection/OutputSharedSecretCredentials.java
@@ -6,7 +6,11 @@ import org.bouncycastle.asn1.cmp.PBMParameter;
 import org.bouncycastle.asn1.pkcs.PBKDF2Params;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 
-public class SharedSecretCredentials implements SharedSecretCredentialContext {
+/**
+ * an instance implementing {@link com.siemens.pki.cmpracomponent.configuration.SharedSecretCredentialContext}
+ * provides all attributes needed for shared secret based CMP protection of outgoing messages
+ */
+public class OutputSharedSecretCredentials implements SharedSecretCredentialContext {
 
     final int iterationCount;
     final int keyLength;
@@ -17,7 +21,14 @@ public class SharedSecretCredentials implements SharedSecretCredentialContext {
     final byte[] senderKID;
     final byte[] sharedSecret;
 
-    public SharedSecretCredentials(final PBMParameter pbmParameter, final byte[] senderKID, final byte[] sharedSecret) {
+    /**
+     * Constructor for password-based MAC protection
+     * @param pbmParameter  PBM parameter
+     * @param senderKID sender key identifier
+     * @param sharedSecret  shared secret
+     */
+    public OutputSharedSecretCredentials(
+            final PBMParameter pbmParameter, final byte[] senderKID, final byte[] sharedSecret) {
         this.iterationCount = pbmParameter.getIterationCount().getValue().intValue();
         this.macAlgorithm = pbmParameter.getMac().getAlgorithm().getId();
         this.passwordBasedMacAlgorithm = CMPObjectIdentifiers.passwordBasedMac.getId();
@@ -29,7 +40,14 @@ public class SharedSecretCredentials implements SharedSecretCredentialContext {
         this.keyLength = 0;
     }
 
-    public SharedSecretCredentials(
+    /**
+     * Constructor for PMAC1 protection
+     * @param pbkdf2Params parameters for PBKDF2 key derivation function
+     * @param macAlgorithm MAC algorithm
+     * @param senderKID sender key identifer
+     * @param sharedSecret shared secret
+     */
+    public OutputSharedSecretCredentials(
             PBKDF2Params pbkdf2Params, String macAlgorithm, byte[] senderKID, byte[] sharedSecret) {
         this.iterationCount = pbkdf2Params.getIterationCount().intValue();
         this.macAlgorithm = macAlgorithm;

--- a/src/main/java/com/siemens/pki/cmpracomponent/protection/SharedSecretCredentials.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/protection/SharedSecretCredentials.java
@@ -17,9 +17,7 @@ public class SharedSecretCredentials implements SharedSecretCredentialContext {
     final byte[] senderKID;
     final byte[] sharedSecret;
 
-    public SharedSecretCredentials(final PBMParameter pbmParameter,
-                                   final byte[] senderKID,
-                                   final byte[] sharedSecret) {
+    public SharedSecretCredentials(final PBMParameter pbmParameter, final byte[] senderKID, final byte[] sharedSecret) {
         this.iterationCount = pbmParameter.getIterationCount().getValue().intValue();
         this.macAlgorithm = pbmParameter.getMac().getAlgorithm().getId();
         this.passwordBasedMacAlgorithm = CMPObjectIdentifiers.passwordBasedMac.getId();
@@ -31,10 +29,8 @@ public class SharedSecretCredentials implements SharedSecretCredentialContext {
         this.keyLength = 0;
     }
 
-    public SharedSecretCredentials(PBKDF2Params pbkdf2Params,
-                                   String macAlgorithm,
-                                   byte[] senderKID,
-                                   byte[] sharedSecret) {
+    public SharedSecretCredentials(
+            PBKDF2Params pbkdf2Params, String macAlgorithm, byte[] senderKID, byte[] sharedSecret) {
         this.iterationCount = pbkdf2Params.getIterationCount().intValue();
         this.macAlgorithm = macAlgorithm;
         this.keyLength = pbkdf2Params.getKeyLength().intValue();

--- a/src/main/java/com/siemens/pki/cmpracomponent/protection/SharedSecretCredentials.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/protection/SharedSecretCredentials.java
@@ -1,0 +1,87 @@
+package com.siemens.pki.cmpracomponent.protection;
+
+import com.siemens.pki.cmpracomponent.configuration.SharedSecretCredentialContext;
+import org.bouncycastle.asn1.cmp.CMPObjectIdentifiers;
+import org.bouncycastle.asn1.cmp.PBMParameter;
+import org.bouncycastle.asn1.pkcs.PBKDF2Params;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+
+public class SharedSecretCredentials implements SharedSecretCredentialContext {
+
+    final int iterationCount;
+    final int keyLength;
+    final String macAlgorithm;
+    final String passwordBasedMacAlgorithm;
+    final String prf;
+    final byte[] salt;
+    final byte[] senderKID;
+    final byte[] sharedSecret;
+
+    public SharedSecretCredentials(final PBMParameter pbmParameter,
+                                   final byte[] senderKID,
+                                   final byte[] sharedSecret) {
+        this.iterationCount = pbmParameter.getIterationCount().getValue().intValue();
+        this.macAlgorithm = pbmParameter.getMac().getAlgorithm().getId();
+        this.passwordBasedMacAlgorithm = CMPObjectIdentifiers.passwordBasedMac.getId();
+        this.prf = pbmParameter.getOwf().getAlgorithm().getId();
+        this.salt = pbmParameter.getSalt().getOctets();
+        this.senderKID = senderKID;
+        this.sharedSecret = sharedSecret;
+
+        this.keyLength = 0;
+    }
+
+    public SharedSecretCredentials(PBKDF2Params pbkdf2Params,
+                                   String macAlgorithm,
+                                   byte[] senderKID,
+                                   byte[] sharedSecret) {
+        this.iterationCount = pbkdf2Params.getIterationCount().intValue();
+        this.macAlgorithm = macAlgorithm;
+        this.keyLength = pbkdf2Params.getKeyLength().intValue();
+        this.passwordBasedMacAlgorithm = PKCSObjectIdentifiers.id_PBMAC1.getId();
+        this.prf = pbkdf2Params.getPrf().getAlgorithm().getId();
+        this.salt = pbkdf2Params.getSalt();
+        this.senderKID = senderKID;
+        this.sharedSecret = sharedSecret;
+    }
+
+    @Override
+    public int getIterationCount() {
+        return iterationCount;
+    }
+
+    @Override
+    public int getkeyLength() {
+        return keyLength;
+    }
+
+    @Override
+    public String getMacAlgorithm() {
+        return macAlgorithm;
+    }
+
+    @Override
+    public String getPasswordBasedMacAlgorithm() {
+        return passwordBasedMacAlgorithm;
+    }
+
+    @Override
+    public String getPrf() {
+        return prf;
+    }
+
+    @Override
+    public byte[] getSalt() {
+        return salt;
+    }
+
+    @Override
+    public byte[] getSenderKID() {
+        return senderKID;
+    }
+
+    @Override
+    public byte[] getSharedSecret() {
+        return sharedSecret;
+    }
+}

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/MacProtectionTestcaseBase.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/MacProtectionTestcaseBase.java
@@ -17,6 +17,8 @@
  */
 package com.siemens.pki.cmpracomponent.test;
 
+import static org.junit.Assert.assertEquals;
+
 import com.siemens.pki.cmpracomponent.configuration.Configuration;
 import com.siemens.pki.cmpracomponent.msggeneration.PkiMessageGenerator;
 import com.siemens.pki.cmpracomponent.protection.MacProtection;
@@ -25,6 +27,8 @@ import com.siemens.pki.cmpracomponent.test.framework.ConfigurationFactory;
 import com.siemens.pki.cmpracomponent.test.framework.EnrollmentResult;
 import com.siemens.pki.cmpracomponent.test.framework.HeaderProviderForTest;
 import com.siemens.pki.cmpracomponent.util.MessageDumper;
+import java.security.KeyPair;
+import java.util.function.Function;
 import org.bouncycastle.asn1.cmp.CMPCertificate;
 import org.bouncycastle.asn1.cmp.CertRepMessage;
 import org.bouncycastle.asn1.cmp.PKIBody;
@@ -35,11 +39,6 @@ import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.junit.Before;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.security.KeyPair;
-import java.util.function.Function;
-
-import static org.junit.Assert.assertEquals;
 
 public class MacProtectionTestcaseBase extends OnlineEnrollmentTestcaseBase {
 

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/MacProtectionTestcaseBase.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/MacProtectionTestcaseBase.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Siemens AG
+ *  Copyright (c) 2024 Siemens AG
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.
@@ -17,8 +17,6 @@
  */
 package com.siemens.pki.cmpracomponent.test;
 
-import static org.junit.Assert.assertEquals;
-
 import com.siemens.pki.cmpracomponent.configuration.Configuration;
 import com.siemens.pki.cmpracomponent.msggeneration.PkiMessageGenerator;
 import com.siemens.pki.cmpracomponent.protection.MacProtection;
@@ -27,8 +25,6 @@ import com.siemens.pki.cmpracomponent.test.framework.ConfigurationFactory;
 import com.siemens.pki.cmpracomponent.test.framework.EnrollmentResult;
 import com.siemens.pki.cmpracomponent.test.framework.HeaderProviderForTest;
 import com.siemens.pki.cmpracomponent.util.MessageDumper;
-import java.security.KeyPair;
-import java.util.function.Function;
 import org.bouncycastle.asn1.cmp.CMPCertificate;
 import org.bouncycastle.asn1.cmp.CertRepMessage;
 import org.bouncycastle.asn1.cmp.PKIBody;
@@ -40,13 +36,19 @@ import org.junit.Before;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class MacProtectionTestcasebase extends OnlineEnrollmentTestcaseBase {
+import java.security.KeyPair;
+import java.util.function.Function;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(MacProtectionTestcasebase.class);
+import static org.junit.Assert.assertEquals;
+
+public class MacProtectionTestcaseBase extends OnlineEnrollmentTestcaseBase {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MacProtectionTestcaseBase.class);
 
     @Before
     public void setUp() throws Exception {
-        final Configuration config = ConfigurationFactory.buildMixedDownstreamConfiguration();
+        ConfigurationFactory.resetConfiguration();
+        Configuration config = ConfigurationFactory.buildMixedDownstreamConfiguration();
         launchCmpCaAndRa(config);
     }
 

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/MacProtectionTestcasebase.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/MacProtectionTestcasebase.java
@@ -1,0 +1,120 @@
+/*
+ *  Copyright (c) 2022 Siemens AG
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+package com.siemens.pki.cmpracomponent.test;
+
+import static org.junit.Assert.assertEquals;
+
+import com.siemens.pki.cmpracomponent.configuration.Configuration;
+import com.siemens.pki.cmpracomponent.msggeneration.PkiMessageGenerator;
+import com.siemens.pki.cmpracomponent.protection.MacProtection;
+import com.siemens.pki.cmpracomponent.protection.ProtectionProvider;
+import com.siemens.pki.cmpracomponent.test.framework.ConfigurationFactory;
+import com.siemens.pki.cmpracomponent.test.framework.EnrollmentResult;
+import com.siemens.pki.cmpracomponent.test.framework.HeaderProviderForTest;
+import com.siemens.pki.cmpracomponent.util.MessageDumper;
+import java.security.KeyPair;
+import java.util.function.Function;
+import org.bouncycastle.asn1.cmp.CMPCertificate;
+import org.bouncycastle.asn1.cmp.CertRepMessage;
+import org.bouncycastle.asn1.cmp.PKIBody;
+import org.bouncycastle.asn1.cmp.PKIMessage;
+import org.bouncycastle.asn1.crmf.CertTemplateBuilder;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.junit.Before;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MacProtectionTestcasebase extends OnlineEnrollmentTestcaseBase {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MacProtectionTestcasebase.class);
+
+    @Before
+    public void setUp() throws Exception {
+        final Configuration config = ConfigurationFactory.buildMixedDownstreamConfiguration();
+        launchCmpCaAndRa(config);
+    }
+
+    public static EnrollmentResult executeCrmfCertificateRequest(
+            final int requestMessageType,
+            final int expectedResponseMessageType,
+            final ProtectionProvider protectionProvider,
+            final String expectedResponseProtection,
+            final Function<PKIMessage, PKIMessage> cmpClient)
+            throws Exception {
+        final KeyPair keyPair = ConfigurationFactory.getKeyGenerator().generateKeyPair();
+        final CertTemplateBuilder ctb = new CertTemplateBuilder()
+                .setPublicKey(
+                        SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded()))
+                .setSubject(new X500Name("CN=Subject"));
+
+        final PKIBody crBody =
+                PkiMessageGenerator.generateIrCrKurBody(requestMessageType, ctb.build(), null, keyPair.getPrivate());
+
+        final PKIMessage cr = PkiMessageGenerator.generateAndProtectMessage(
+                new HeaderProviderForTest("theCertProfileForOnlineEnrollment"), protectionProvider, crBody);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("send:\n" + MessageDumper.dumpPkiMessage(cr));
+        }
+        final PKIMessage crResponse = cmpClient.apply(cr);
+
+        if (LOGGER.isDebugEnabled()) {
+            // avoid unnecessary string processing, if debug isn't enabled
+            LOGGER.debug("got:\n" + MessageDumper.dumpPkiMessage(crResponse));
+        }
+        assertEquals(
+                "message type",
+                expectedResponseMessageType,
+                crResponse.getBody().getType());
+
+        if (protectionProvider instanceof MacProtection) {
+            assertEquals(
+                    "protection type",
+                    expectedResponseProtection,
+                    crResponse.getHeader().getProtectionAlg().getAlgorithm().getId());
+        }
+
+        if (expectedResponseMessageType == PKIBody.TYPE_ERROR) {
+            return new EnrollmentResult(null, null);
+        } else {
+            final CMPCertificate enrolledCertificate = ((CertRepMessage)
+                            crResponse.getBody().getContent())
+                    .getResponse()[0]
+                    .getCertifiedKeyPair()
+                    .getCertOrEncCert()
+                    .getCertificate();
+
+            final PKIMessage certConf = PkiMessageGenerator.generateAndProtectMessage(
+                    new HeaderProviderForTest(crResponse.getHeader()),
+                    protectionProvider,
+                    PkiMessageGenerator.generateCertConfBody(enrolledCertificate));
+
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("send:\n" + MessageDumper.dumpPkiMessage(certConf));
+            }
+            final PKIMessage pkiConf = cmpClient.apply(certConf);
+
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("got:\n" + MessageDumper.dumpPkiMessage(pkiConf));
+            }
+            assertEquals("message type", PKIBody.TYPE_CONFIRM, pkiConf.getBody().getType());
+
+            return new EnrollmentResult(enrolledCertificate, keyPair.getPrivate());
+        }
+    }
+}

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/OnlineEnrollmentTestcaseBase.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/OnlineEnrollmentTestcaseBase.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 
 import com.siemens.pki.cmpracomponent.cryptoservices.AlgorithmHelper;
 import com.siemens.pki.cmpracomponent.msggeneration.PkiMessageGenerator;
+import com.siemens.pki.cmpracomponent.protection.MacProtection;
 import com.siemens.pki.cmpracomponent.protection.ProtectionProvider;
 import com.siemens.pki.cmpracomponent.test.framework.ConfigurationFactory;
 import com.siemens.pki.cmpracomponent.test.framework.EnrollmentResult;
@@ -77,6 +78,13 @@ public class OnlineEnrollmentTestcaseBase extends EnrollmentTestcaseBase {
                 "message type",
                 expectedResponseMessageType,
                 crResponse.getBody().getType());
+
+        if (protectionProvider instanceof MacProtection) {
+            assertEquals(
+                    "protection type",
+                    cr.getHeader().getProtectionAlg().getAlgorithm().getId(),
+                    crResponse.getHeader().getProtectionAlg().getAlgorithm().getId());
+        }
 
         final CMPCertificate enrolledCertificate = ((CertRepMessage)
                         crResponse.getBody().getContent())

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/PasswordEnrollmentTestcasebase.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/PasswordEnrollmentTestcasebase.java
@@ -25,6 +25,7 @@ public class PasswordEnrollmentTestcasebase extends OnlineEnrollmentTestcaseBase
 
     @Before
     public void setUp() throws Exception {
+        ConfigurationFactory.resetConfiguration();
         final Configuration config = ConfigurationFactory.buildPasswordbasedDownstreamConfiguration();
         launchCmpCaAndRa(config);
     }

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/Pbmac1EnrollmentTestcasebase.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/Pbmac1EnrollmentTestcasebase.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Siemens AG
+ *  Copyright (c) 2022 Siemens AG
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.
@@ -17,18 +17,15 @@
  */
 package com.siemens.pki.cmpracomponent.test;
 
+import com.siemens.pki.cmpracomponent.configuration.Configuration;
 import com.siemens.pki.cmpracomponent.test.framework.ConfigurationFactory;
-import org.bouncycastle.asn1.cmp.PKIBody;
-import org.junit.Test;
+import org.junit.Before;
 
-public class TestPasswordbasedIr extends PasswordEnrollmentTestcasebase {
+public class Pbmac1EnrollmentTestcasebase extends OnlineEnrollmentTestcaseBase {
 
-    @Test
-    public void testPasswordbasedIr() throws Exception {
-        executeCrmfCertificateRequest(
-                PKIBody.TYPE_INIT_REQ,
-                PKIBody.TYPE_INIT_REP,
-                ConfigurationFactory.getEePasswordbasedProtectionProvider(),
-                getEeClient());
+    @Before
+    public void setUp() throws Exception {
+        final Configuration config = ConfigurationFactory.buildPbmac1DownstreamConfiguration();
+        launchCmpCaAndRa(config);
     }
 }

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/Pbmac1EnrollmentTestcasebase.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/Pbmac1EnrollmentTestcasebase.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Siemens AG
+ *  Copyright (c) 2024 Siemens AG
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/TestMacProtectedIp.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/TestMacProtectedIp.java
@@ -19,16 +19,44 @@ package com.siemens.pki.cmpracomponent.test;
 
 import com.siemens.pki.cmpracomponent.test.framework.ConfigurationFactory;
 import org.bouncycastle.asn1.cmp.PKIBody;
+import org.junit.Ignore;
 import org.junit.Test;
 
-public class TestPasswordbasedIr extends PasswordEnrollmentTestcasebase {
+public class TestMacProtectedIp extends MacProtectionTestcasebase {
+
+    @Ignore
+    public void testFailedProtectionIp() throws Exception {
+        executeCrmfCertificateRequest(
+                PKIBody.TYPE_INIT_REQ,
+                PKIBody.TYPE_ERROR,
+                ConfigurationFactory.getEeWrongPasswordbasedProtectionProvider(),
+                "1.2.840.10045.4.3.2", // signature based protection
+                getEeClient());
+    }
 
     @Test
-    public void testPasswordbasedIr() throws Exception {
+    public void testPasswordbasedIp() throws Exception {
         executeCrmfCertificateRequest(
                 PKIBody.TYPE_INIT_REQ,
                 PKIBody.TYPE_INIT_REP,
                 ConfigurationFactory.getEePasswordbasedProtectionProvider(),
+                "1.2.840.113533.7.66.13",
+                getEeClient());
+    }
+
+    /**
+     * Enrolling an End Entity to a New PKI/Using MAC-Based Protection for
+     * Enrollment
+     *
+     * @throws Exception in case of error
+     */
+    @Test
+    public void testPbmac1Ip() throws Exception {
+        executeCrmfCertificateRequest(
+                PKIBody.TYPE_INIT_REQ,
+                PKIBody.TYPE_INIT_REP,
+                ConfigurationFactory.getEePbmac1ProtectionProvider(),
+                "1.2.840.113549.1.5.14",
                 getEeClient());
     }
 }

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/TestMacProtectedIp.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/TestMacProtectedIp.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Siemens AG
+ *  Copyright (c) 2024 Siemens AG
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.
@@ -19,12 +19,11 @@ package com.siemens.pki.cmpracomponent.test;
 
 import com.siemens.pki.cmpracomponent.test.framework.ConfigurationFactory;
 import org.bouncycastle.asn1.cmp.PKIBody;
-import org.junit.Ignore;
 import org.junit.Test;
 
-public class TestMacProtectedIp extends MacProtectionTestcasebase {
+public class TestMacProtectedIp extends MacProtectionTestcaseBase {
 
-    @Ignore
+    @Test
     public void testFailedProtectionIp() throws Exception {
         executeCrmfCertificateRequest(
                 PKIBody.TYPE_INIT_REQ,

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/TestPbmac1Ir.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/TestPbmac1Ir.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 Siemens AG
+ *  Copyright (c) 2024 Siemens AG
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/TestPbmac1Ir.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/TestPbmac1Ir.java
@@ -21,14 +21,20 @@ import com.siemens.pki.cmpracomponent.test.framework.ConfigurationFactory;
 import org.bouncycastle.asn1.cmp.PKIBody;
 import org.junit.Test;
 
-public class TestPasswordbasedIr extends PasswordEnrollmentTestcasebase {
+public class TestPbmac1Ir extends PasswordEnrollmentTestcasebase {
 
+    /**
+     * Enrolling an End Entity to a New PKI/Using MAC-Based Protection for
+     * Enrollment
+     *
+     * @throws Exception in case of error
+     */
     @Test
-    public void testPasswordbasedIr() throws Exception {
+    public void testPbmac1Ir() throws Exception {
         executeCrmfCertificateRequest(
                 PKIBody.TYPE_INIT_REQ,
                 PKIBody.TYPE_INIT_REP,
-                ConfigurationFactory.getEePasswordbasedProtectionProvider(),
+                ConfigurationFactory.getEePbmac1ProtectionProvider(),
                 getEeClient());
     }
 }

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/framework/ConfigurationFactory.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/framework/ConfigurationFactory.java
@@ -17,6 +17,9 @@
  */
 package com.siemens.pki.cmpracomponent.test.framework;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
 import com.siemens.pki.cmpracomponent.configuration.CheckAndModifyResult;
 import com.siemens.pki.cmpracomponent.configuration.CkgContext;
 import com.siemens.pki.cmpracomponent.configuration.CmpMessageInterface;
@@ -38,17 +41,6 @@ import com.siemens.pki.cmpracomponent.persistency.DefaultPersistencyImplementati
 import com.siemens.pki.cmpracomponent.protection.ProtectionProvider;
 import com.siemens.pki.cmpracomponent.protection.ProtectionProviderFactory;
 import com.siemens.pki.cmpracomponent.util.MessageDumper;
-import org.bouncycastle.asn1.ASN1Integer;
-import org.bouncycastle.asn1.ASN1Sequence;
-import org.bouncycastle.asn1.cmp.CMPObjectIdentifiers;
-import org.bouncycastle.asn1.cmp.CertReqTemplateContent;
-import org.bouncycastle.asn1.crmf.AttributeTypeAndValue;
-import org.bouncycastle.asn1.crmf.CertTemplateBuilder;
-import org.bouncycastle.asn1.crmf.Controls;
-import org.bouncycastle.asn1.x500.X500Name;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.GeneralSecurityException;
@@ -62,9 +54,16 @@ import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Collections;
-
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import org.bouncycastle.asn1.ASN1Integer;
+import org.bouncycastle.asn1.ASN1Sequence;
+import org.bouncycastle.asn1.cmp.CMPObjectIdentifiers;
+import org.bouncycastle.asn1.cmp.CertReqTemplateContent;
+import org.bouncycastle.asn1.crmf.AttributeTypeAndValue;
+import org.bouncycastle.asn1.crmf.CertTemplateBuilder;
+import org.bouncycastle.asn1.crmf.Controls;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * builder class for {@link Configuration} objects

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/framework/ConfigurationFactory.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/framework/ConfigurationFactory.java
@@ -82,7 +82,48 @@ public class ConfigurationFactory {
     private static SharedSecret eeSharedSecretCredentials;
 
     public static Configuration buildPasswordbasedDownstreamConfiguration() throws Exception {
+        final CredentialContext downstreamCredentials = new SharedSecret("PASSWORDBASEDMAC", TestUtils.PASSWORD);
+        final VerificationContext downstreamTrust = new PasswordValidationCredentials(TestUtils.PASSWORD);
+
+        final CredentialContext upstreamCredentials =
+                new TrustChainAndPrivateKey("credentials/CMP_LRA_UPSTREAM_Keystore.p12", "Password".toCharArray());
+        final VerificationContext upstreamTrust =
+                new SignatureValidationCredentials("credentials/CMP_CA_Root.pem", null);
+        final SignatureValidationCredentials enrollmentTrust =
+                new SignatureValidationCredentials("credentials/ENROLL_Root.pem", null);
+
+        return buildSimpleRaConfiguration(
+                downstreamCredentials,
+                ReprotectMode.reprotect,
+                downstreamTrust,
+                upstreamCredentials,
+                upstreamTrust,
+                enrollmentTrust);
+    }
+
+    public static Configuration buildPbmac1DownstreamConfiguration() throws Exception {
         final CredentialContext downstreamCredentials = new SharedSecret("PBMAC1", TestUtils.PASSWORD);
+        final VerificationContext downstreamTrust = new PasswordValidationCredentials(TestUtils.PASSWORD);
+
+        final CredentialContext upstreamCredentials =
+                new TrustChainAndPrivateKey("credentials/CMP_LRA_UPSTREAM_Keystore.p12", "Password".toCharArray());
+        final VerificationContext upstreamTrust =
+                new SignatureValidationCredentials("credentials/CMP_CA_Root.pem", null);
+        final SignatureValidationCredentials enrollmentTrust =
+                new SignatureValidationCredentials("credentials/ENROLL_Root.pem", null);
+
+        return buildSimpleRaConfiguration(
+                downstreamCredentials,
+                ReprotectMode.reprotect,
+                downstreamTrust,
+                upstreamCredentials,
+                upstreamTrust,
+                enrollmentTrust);
+    }
+
+    public static Configuration buildMixedDownstreamConfiguration() throws Exception {
+        final TrustChainAndPrivateKey downstreamCredentials =
+                new TrustChainAndPrivateKey("credentials/CMP_LRA_DOWNSTREAM_Keystore.p12", "Password".toCharArray());
         final VerificationContext downstreamTrust = new PasswordValidationCredentials(TestUtils.PASSWORD);
 
         final CredentialContext upstreamCredentials =
@@ -746,6 +787,15 @@ public class ConfigurationFactory {
         return eePasswordbasedProtectionProvider;
     }
 
+    public static ProtectionProvider getEeWrongPasswordbasedProtectionProvider()
+            throws InvalidKeyException, NoSuchAlgorithmException, InvalidKeySpecException {
+        if (eePasswordbasedProtectionProvider == null) {
+            eePasswordbasedProtectionProvider = ProtectionProviderFactory.createProtectionProvider(
+                    getEeWrongSharedSecretCredentials(), INTERFACE_NAME);
+        }
+        return eePasswordbasedProtectionProvider;
+    }
+
     public static ProtectionProvider getEePbmac1ProtectionProvider()
             throws InvalidKeyException, NoSuchAlgorithmException, InvalidKeySpecException {
         if (eePbmac1ProtectionProvider == null) {
@@ -758,6 +808,13 @@ public class ConfigurationFactory {
     private static SharedSecret getEeSharedSecretCredentials() {
         if (eeSharedSecretCredentials == null) {
             eeSharedSecretCredentials = new SharedSecret("PASSWORDBASEDMAC", TestUtils.PASSWORD);
+        }
+        return eeSharedSecretCredentials;
+    }
+
+    private static SharedSecret getEeWrongSharedSecretCredentials() {
+        if (eeSharedSecretCredentials == null) {
+            eeSharedSecretCredentials = new SharedSecret("PASSWORDBASEDMAC", TestUtils.WRONG_PASSWORD);
         }
         return eeSharedSecretCredentials;
     }

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/framework/ConfigurationFactory.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/framework/ConfigurationFactory.java
@@ -17,9 +17,6 @@
  */
 package com.siemens.pki.cmpracomponent.test.framework;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
-
 import com.siemens.pki.cmpracomponent.configuration.CheckAndModifyResult;
 import com.siemens.pki.cmpracomponent.configuration.CkgContext;
 import com.siemens.pki.cmpracomponent.configuration.CmpMessageInterface;
@@ -41,6 +38,17 @@ import com.siemens.pki.cmpracomponent.persistency.DefaultPersistencyImplementati
 import com.siemens.pki.cmpracomponent.protection.ProtectionProvider;
 import com.siemens.pki.cmpracomponent.protection.ProtectionProviderFactory;
 import com.siemens.pki.cmpracomponent.util.MessageDumper;
+import org.bouncycastle.asn1.ASN1Integer;
+import org.bouncycastle.asn1.ASN1Sequence;
+import org.bouncycastle.asn1.cmp.CMPObjectIdentifiers;
+import org.bouncycastle.asn1.cmp.CertReqTemplateContent;
+import org.bouncycastle.asn1.crmf.AttributeTypeAndValue;
+import org.bouncycastle.asn1.crmf.CertTemplateBuilder;
+import org.bouncycastle.asn1.crmf.Controls;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.GeneralSecurityException;
@@ -54,16 +62,9 @@ import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Collections;
-import org.bouncycastle.asn1.ASN1Integer;
-import org.bouncycastle.asn1.ASN1Sequence;
-import org.bouncycastle.asn1.cmp.CMPObjectIdentifiers;
-import org.bouncycastle.asn1.cmp.CertReqTemplateContent;
-import org.bouncycastle.asn1.crmf.AttributeTypeAndValue;
-import org.bouncycastle.asn1.crmf.CertTemplateBuilder;
-import org.bouncycastle.asn1.crmf.Controls;
-import org.bouncycastle.asn1.x500.X500Name;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 /**
  * builder class for {@link Configuration} objects
@@ -851,6 +852,15 @@ public class ConfigurationFactory {
             }
         }
         return keyGenerator;
+    }
+
+    public static void resetConfiguration() {
+        eeSignaturebasedProtectionProvider = null;
+        eePbmac1ProtectionProvider = null;
+        keyGenerator = null;
+        eePasswordbasedProtectionProvider = null;
+        eeSignaturebasedCredentials = null;
+        eeSharedSecretCredentials = null;
     }
 
     private ConfigurationFactory() {}

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/framework/TestUtils.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/framework/TestUtils.java
@@ -26,6 +26,9 @@ public class TestUtils {
 
     public static final String PASSWORD = "Password";
     public static final char[] PASSWORD_AS_CHAR_ARRAY = PASSWORD.toCharArray();
+
+    public static final String WRONG_PASSWORD = "WrongPassword";
+    public static final char[] WRONG_PASSWORD_AS_CHAR_ARRAY = WRONG_PASSWORD.toCharArray();
     static final SecureRandom RANDOM = new SecureRandom();
 
     // utility class, never create an instance


### PR DESCRIPTION
Addresses issue #91 

- Introduced new container class `MessageContext` to store persistency context and verification credentials of incoming messages
- If outgoing message is configured to be reprotected, any configuration of outgoing credentials is ignored and the verification credentials are used instead
- In case of failed protection validation the configured outgoing credentials are used for the outgoing error message