### PR TITLE
again fix protection of NESTED responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,3 +140,6 @@ feat: add logging while accessing configuration data
 
 fix: handling of NestedEndpointContext.isIncomingRecipientValid
 
+### 4.1.4 (Jul 23 2024)
+
+fix: again fix protection of NESTED responses

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<groupId>com.siemens.pki</groupId>
 	<artifactId>CmpRaComponent</artifactId>
 	<packaging>jar</packaging>
-	<version>4.1.3</version>
+	<version>4.1.4</version>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<parent.basedir>.</parent.basedir>

--- a/src/main/java/com/siemens/pki/cmpracomponent/msggeneration/MsgOutputProtector.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msggeneration/MsgOutputProtector.java
@@ -29,6 +29,7 @@ import com.siemens.pki.cmpracomponent.persistency.PersistencyContext;
 import com.siemens.pki.cmpracomponent.protection.ProtectionProvider;
 import com.siemens.pki.cmpracomponent.protection.ProtectionProviderFactory;
 import com.siemens.pki.cmpracomponent.util.ConfigLogger;
+import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -123,9 +124,11 @@ public class MsgOutputProtector {
      * @param headerProvider the header to use
      * @param body body of new message
      * @return new message
-     * @throws Exception in case of error
+     * @throws IOException in case of encoding problem
+     * @throws GeneralSecurityException in case of error
      */
-    public PKIMessage createOutgoingMessage(final HeaderProvider headerProvider, PKIBody body) throws Exception {
+    public PKIMessage createOutgoingMessage(final HeaderProvider headerProvider, PKIBody body)
+            throws GeneralSecurityException, IOException {
         switch (reprotectMode) {
             case reprotect:
             case keep:
@@ -145,9 +148,11 @@ public class MsgOutputProtector {
      * @param request request to answer
      * @param body    body of new message
      * @return new message
-     * @throws Exception in case of error
+     * @throws GeneralSecurityException in case of error
+     * @throws IOException in case of encoding error
      */
-    public PKIMessage generateAndProtectResponseTo(PKIMessage request, final PKIBody body) throws Exception {
+    public PKIMessage generateAndProtectResponseTo(PKIMessage request, final PKIBody body)
+            throws GeneralSecurityException, IOException {
         return stripRedundantExtraCerts(PkiMessageGenerator.generateAndProtectMessage(
                 PkiMessageGenerator.buildRespondingHeaderProvider(request), protector, recipient, body, null));
     }
@@ -166,10 +171,11 @@ public class MsgOutputProtector {
      * @param issuingChain trust chain of issued certificate to add to extracerts or
      *                     <code>null</code>
      * @return protected message ready to send
-     * @throws Exception in case of processing error
+     * @throws IOException in case of encoding problem
+     * @throws GeneralSecurityException in case of processing error
      */
     public PKIMessage protectOutgoingMessage(final PKIMessage in, final List<CMPCertificate> issuingChain)
-            throws Exception {
+            throws GeneralSecurityException, IOException {
         switch (reprotectMode) {
             case reprotect:
                 return stripRedundantExtraCerts(PkiMessageGenerator.generateAndProtectMessage(

--- a/src/main/java/com/siemens/pki/cmpracomponent/msggeneration/PkiMessageGenerator.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msggeneration/PkiMessageGenerator.java
@@ -29,6 +29,7 @@ import com.siemens.pki.cmpracomponent.protection.ProtectionProvider;
 import com.siemens.pki.cmpracomponent.util.MessageDumper;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.security.GeneralSecurityException;
 import java.security.PrivateKey;
 import java.security.Signature;
 import java.util.Collections;
@@ -257,7 +258,8 @@ public class PkiMessageGenerator {
      * @param issuingChain       chain of enrolled certificate to append at the
      *                           extraCerts
      * @return a fully build and protected message
-     * @throws Exception in case of error
+     * @throws GeneralSecurityException in case of error
+     * @throws IOException in case of encoding error
      */
     public static PKIMessage generateAndProtectMessage(
             final HeaderProvider headerProvider,
@@ -265,7 +267,7 @@ public class PkiMessageGenerator {
             GeneralName newRecipient,
             final PKIBody body,
             final List<CMPCertificate> issuingChain)
-            throws Exception {
+            throws GeneralSecurityException, IOException {
         synchronized (protectionProvider) {
             final GeneralName recipient = computeDefaultIfNull(newRecipient, headerProvider::getRecipient);
             final GeneralName sender = computeDefaultIfNull(protectionProvider.getSender(), headerProvider::getSender);
@@ -422,11 +424,12 @@ public class PkiMessageGenerator {
      * @param privateKey   private key to build the POPO, if set to null, POPO is
      *                     set to raVerified
      * @return a IR, CR or KUR body
-     * @throws Exception in case of error
+     * @throws GeneralSecurityException in case of error
+     * @throws IOException in case of encoding error
      */
     public static PKIBody generateIrCrKurBody(
             final int bodyType, final CertTemplate certTemplate, final Controls controls, final PrivateKey privateKey)
-            throws Exception {
+            throws GeneralSecurityException, IOException {
         final CertRequest certReq = new CertRequest(CERT_REQ_ID_0, certTemplate, controls);
         if (privateKey == null) {
             return new PKIBody(bodyType, new CertReqMessages(new CertReqMsg(certReq, new ProofOfPossession(), null)));
@@ -542,10 +545,11 @@ public class PkiMessageGenerator {
      * @param headerProvider PKI header
      * @param body           message body
      * @return a fully build and not protected message
-     * @throws Exception in case of error
+     * @throws GeneralSecurityException in case of error
+     * @throws IOException in case of encoding error
      */
     public static PKIMessage generateUnprotectMessage(final HeaderProvider headerProvider, final PKIBody body)
-            throws Exception {
+            throws GeneralSecurityException, IOException {
         return generateAndProtectMessage(headerProvider, ProtectionProvider.NO_PROTECTION, null, body, null);
     }
 

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/ServiceImplementation.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgprocessing/ServiceImplementation.java
@@ -76,7 +76,7 @@ class ServiceImplementation {
      * @param config specific configuration
      * @throws Exception in case of error
      */
-    ServiceImplementation(final Configuration config) throws Exception {
+    ServiceImplementation(final Configuration config) {
         this.config = config;
     }
 

--- a/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/MessageBodyValidator.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/MessageBodyValidator.java
@@ -189,15 +189,17 @@ public class MessageBodyValidator implements ValidatorIF<String> {
     @Override
     public String validate(final PKIMessage message) throws BaseCmpException {
         try {
-            final ASN1GeneralizedTime messageTime = message.getHeader().getMessageTime();
-            if (messageTime != null) {
-                final long diffInMillis = messageTime.getDate().getTime() - new Date().getTime();
-                if (!ConfigLogger.log(
-                        interfaceName,
-                        "CmpMessageInterface.isMessageTimeDeviationAllowed(long)",
-                        () -> cmpInterfaceConfig.isMessageTimeDeviationAllowed(diffInMillis / 1000L))) {
-                    throw new CmpValidationException(
-                            interfaceName, PKIFailureInfo.badTime, "message time out of allowed range");
+            if (cmpInterfaceConfig != null) {
+                final ASN1GeneralizedTime messageTime = message.getHeader().getMessageTime();
+                if (messageTime != null) {
+                    final long diffInMillis = messageTime.getDate().getTime() - new Date().getTime();
+                    if (!ConfigLogger.log(
+                            interfaceName,
+                            "CmpMessageInterface.isMessageTimeDeviationAllowed(long)",
+                            () -> cmpInterfaceConfig.isMessageTimeDeviationAllowed(diffInMillis / 1000L))) {
+                        throw new CmpValidationException(
+                                interfaceName, PKIFailureInfo.badTime, "message time out of allowed range");
+                    }
                 }
             }
 
@@ -301,6 +303,7 @@ public class MessageBodyValidator implements ValidatorIF<String> {
         final CertRequest certReq = certReqMsg.getCertReq();
         assertEnrollmentEqual(enrollmentType, certReq.getCertReqId(), ASN1INTEGER_0, CERT_REQ_ID_MUST_BE_0);
         final CertTemplate certTemplate = certReq.getCertTemplate();
+        assertEnrollmentValueNotNull(enrollmentType, certTemplate, PKIFailureInfo.badCertTemplate, "cert template");
         final int versionInTemplate = certTemplate.getVersion();
         if (versionInTemplate != -1 && versionInTemplate != 2) {
             throw new CmpEnrollmentException(

--- a/src/main/java/com/siemens/pki/cmpracomponent/protection/MacProtection.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/protection/MacProtection.java
@@ -23,6 +23,8 @@ import static com.siemens.pki.cmpracomponent.util.NullUtil.ifNotNull;
 import com.siemens.pki.cmpracomponent.configuration.SharedSecretCredentialContext;
 import com.siemens.pki.cmpracomponent.cryptoservices.WrappedMac;
 import com.siemens.pki.cmpracomponent.util.ConfigLogger;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.List;
 import org.bouncycastle.asn1.ASN1Encoding;
 import org.bouncycastle.asn1.DERBitString;
@@ -61,7 +63,8 @@ public abstract class MacProtection implements ProtectionProvider {
     }
 
     @Override
-    public synchronized DERBitString getProtectionFor(final ProtectedPart protectedPart) throws Exception {
+    public synchronized DERBitString getProtectionFor(final ProtectedPart protectedPart)
+            throws GeneralSecurityException, IOException {
         return new DERBitString(protectingMac.calculateMac(protectedPart.getEncoded(ASN1Encoding.DER)));
     }
 

--- a/src/main/java/com/siemens/pki/cmpracomponent/protection/NoProtection.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/protection/NoProtection.java
@@ -17,6 +17,8 @@
  */
 package com.siemens.pki.cmpracomponent.protection;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.List;
 import org.bouncycastle.asn1.DERBitString;
 import org.bouncycastle.asn1.DEROctetString;
@@ -46,7 +48,8 @@ public class NoProtection implements ProtectionProvider {
     }
 
     @Override
-    public DERBitString getProtectionFor(final ProtectedPart protectedPart) throws Exception {
+    public DERBitString getProtectionFor(final ProtectedPart protectedPart)
+            throws GeneralSecurityException, IOException {
         return null;
     }
 

--- a/src/main/java/com/siemens/pki/cmpracomponent/protection/ProtectionProvider.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/protection/ProtectionProvider.java
@@ -17,6 +17,9 @@
  */
 package com.siemens.pki.cmpracomponent.protection;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.cert.CertificateException;
 import java.util.List;
 import org.bouncycastle.asn1.DERBitString;
 import org.bouncycastle.asn1.DEROctetString;
@@ -39,9 +42,10 @@ public interface ProtectionProvider {
     /**
      * get extra certs used for protection
      * @return extra certs used for protection
-     * @throws Exception in case of error
+     * @throws CertificateException in case of error
+     * @throws GeneralSecurityException in case of error
      */
-    List<CMPCertificate> getProtectingExtraCerts() throws Exception;
+    List<CMPCertificate> getProtectingExtraCerts() throws GeneralSecurityException;
 
     /**
      * get protection algorithm
@@ -54,9 +58,10 @@ public interface ProtectionProvider {
      *
      * @param protectedPart message part covered by protection
      * @return the protection string
-     * @throws Exception in case of error
+     * @throws IOException in case of encoding error
+     * @throws GeneralSecurityException in case of error
      */
-    DERBitString getProtectionFor(ProtectedPart protectedPart) throws Exception;
+    DERBitString getProtectionFor(ProtectedPart protectedPart) throws GeneralSecurityException, IOException;
 
     /**
      * get  sender to use for protected message

--- a/src/main/java/com/siemens/pki/cmpracomponent/protection/SignatureBasedProtection.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/protection/SignatureBasedProtection.java
@@ -20,6 +20,8 @@ package com.siemens.pki.cmpracomponent.protection;
 import com.siemens.pki.cmpracomponent.configuration.SignatureCredentialContext;
 import com.siemens.pki.cmpracomponent.cryptoservices.BaseCredentialService;
 import com.siemens.pki.cmpracomponent.cryptoservices.CertUtility;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.security.Signature;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -76,7 +78,8 @@ public class SignatureBasedProtection extends BaseCredentialService implements P
     }
 
     @Override
-    public DERBitString getProtectionFor(final ProtectedPart protectedPart) throws Exception {
+    public DERBitString getProtectionFor(final ProtectedPart protectedPart)
+            throws GeneralSecurityException, IOException {
         final Signature sig = Signature.getInstance(getSignatureAlgorithmName());
         sig.initSign(getPrivateKey());
         sig.update(protectedPart.getEncoded(ASN1Encoding.DER));

--- a/src/test/java/com/siemens/pki/cmpclientcomponent/test/TestP10Cr.java
+++ b/src/test/java/com/siemens/pki/cmpclientcomponent/test/TestP10Cr.java
@@ -136,7 +136,7 @@ public class TestP10Cr extends EnrollmentTestcaseBase {
 
             @Override
             public int getDownstreamTimeout(final String certProfile, final int bodyType) {
-                return 10;
+                return 0;
             }
 
             @Override

--- a/src/test/java/com/siemens/pki/cmpclientcomponent/test/TestUpdateByInventory.java
+++ b/src/test/java/com/siemens/pki/cmpclientcomponent/test/TestUpdateByInventory.java
@@ -18,7 +18,7 @@
 package com.siemens.pki.cmpclientcomponent.test;
 
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 import com.siemens.pki.cmpclientcomponent.configuration.ClientContext;
@@ -42,7 +42,7 @@ import org.bouncycastle.asn1.cmp.PKIBody;
 import org.junit.Before;
 import org.junit.Test;
 
-public class TestRefusingInventory extends EnrollmentTestcaseBase {
+public class TestUpdateByInventory extends EnrollmentTestcaseBase {
 
     private static final String UPSTREAM_TRUST_PATH = "credentials/CMP_CA_and_LRA_DOWNSTREAM_Root.pem";
 
@@ -54,37 +54,14 @@ public class TestRefusingInventory extends EnrollmentTestcaseBase {
     @Test
     public void testCr() throws Exception {
         final EnrollmentResult ret = getSignatureBasedCmpClient(
-                        "refuseMeCr",
+                        "updateTemplateCr",
                         getClientContext(
                                 PKIBody.TYPE_CERT_REQ,
                                 ConfigurationFactory.getKeyGenerator().generateKeyPair(),
                                 null),
                         UPSTREAM_TRUST_PATH)
                 .invokeEnrollment();
-        assertNull(ret);
-    }
-
-    @Test
-    public void testCrWithException() throws Exception {
-        final EnrollmentResult ret = getSignatureBasedCmpClient(
-                        "refuseMeWithException",
-                        getClientContext(
-                                PKIBody.TYPE_CERT_REQ,
-                                ConfigurationFactory.getKeyGenerator().generateKeyPair(),
-                                null),
-                        UPSTREAM_TRUST_PATH)
-                .invokeEnrollment();
-        assertNull(ret);
-    }
-
-    @Test
-    public void testRrRefuse() throws Exception {
-        testRr("refuseMeRr");
-    }
-
-    @Test
-    public void testRrException() throws Exception {
-        testRr("refuseMeWithExceptionRR");
+        assertNotNull(ret);
     }
 
     /**
@@ -92,7 +69,8 @@ public class TestRefusingInventory extends EnrollmentTestcaseBase {
      *
      * @throws Exception
      */
-    private void testRr(String certProfile) throws Exception {
+    @Test
+    public void testRr() throws Exception {
         final CmpClient crClient = getSignatureBasedCmpClient(
                 "theCertProfileForOnlineEnrollment",
                 getClientContext(
@@ -181,7 +159,7 @@ public class TestRefusingInventory extends EnrollmentTestcaseBase {
                 return deviation < 10;
             }
         };
-        final CmpClient rrClient = new CmpClient(certProfile, getUpstreamExchange(), rrUpstream, rrClientContext);
+        final CmpClient rrClient = new CmpClient("refuseMeRr", getUpstreamExchange(), rrUpstream, rrClientContext);
         assertFalse(rrClient.invokeRevocation());
     }
 }

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/CkgOnlineEnrollmentTestcaseBase.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/CkgOnlineEnrollmentTestcaseBase.java
@@ -36,7 +36,6 @@ import com.siemens.pki.cmpracomponent.util.MessageDumper;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.util.function.Function;
-import org.bouncycastle.asn1.ASN1Encoding;
 import org.bouncycastle.asn1.cmp.CMPCertificate;
 import org.bouncycastle.asn1.cmp.CertRepMessage;
 import org.bouncycastle.asn1.cmp.CertResponse;
@@ -77,7 +76,6 @@ public class CkgOnlineEnrollmentTestcaseBase extends OnlineEnrollmentTestcaseBas
                 .setSubject(new X500Name("CN=Subject"));
 
         final CertTemplate template = ctb.build();
-        CertTemplate.getInstance(template.getEncoded(ASN1Encoding.DER));
         final PKIBody crBody = PkiMessageGenerator.generateIrCrKurBody(requestMesssageType, template, null, null);
 
         final PKIMessage cr = PkiMessageGenerator.generateAndProtectMessage(

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/TestMessageBodyValidator.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/TestMessageBodyValidator.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (c) 2024 Siemens AG
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+package com.siemens.pki.cmpracomponent.test;
+
+import com.siemens.pki.cmpracomponent.msgvalidation.BaseCmpException;
+import com.siemens.pki.cmpracomponent.msgvalidation.CmpEnrollmentException;
+import com.siemens.pki.cmpracomponent.msgvalidation.CmpValidationException;
+import com.siemens.pki.cmpracomponent.msgvalidation.MessageBodyValidator;
+import org.bouncycastle.asn1.ASN1Integer;
+import org.bouncycastle.asn1.cmp.CertRepMessage;
+import org.bouncycastle.asn1.cmp.CertResponse;
+import org.bouncycastle.asn1.cmp.ErrorMsgContent;
+import org.bouncycastle.asn1.cmp.PKIBody;
+import org.bouncycastle.asn1.cmp.PKIFailureInfo;
+import org.bouncycastle.asn1.cmp.PKIMessage;
+import org.bouncycastle.asn1.cmp.PKIStatus;
+import org.bouncycastle.asn1.cmp.PKIStatusInfo;
+import org.bouncycastle.asn1.cmp.RevRepContentBuilder;
+import org.bouncycastle.asn1.crmf.CertReqMessages;
+import org.bouncycastle.asn1.crmf.CertReqMsg;
+import org.bouncycastle.asn1.crmf.CertRequest;
+import org.bouncycastle.asn1.crmf.CertTemplateBuilder;
+import org.junit.Test;
+
+public class TestMessageBodyValidator {
+
+    private final MessageBodyValidator validatorUnderTest =
+            new MessageBodyValidator("test validator", (x, y) -> true, null, null);
+
+    @Test(expected = CmpEnrollmentException.class)
+    public void testWrongCertIdInRequest() throws BaseCmpException {
+        PKIBody bodyToTest = new PKIBody(
+                PKIBody.TYPE_CERT_REQ,
+                new CertReqMessages(
+                        new CertReqMsg(new CertRequest(77, (new CertTemplateBuilder()).build(), null), null, null)));
+        validatorUnderTest.validate(new PKIMessage(null, bodyToTest));
+    }
+
+    @Test(expected = CmpValidationException.class)
+    public void testWrongCertIdInResponse() throws BaseCmpException {
+        PKIBody bodyToTest = new PKIBody(PKIBody.TYPE_CERT_REP, new CertRepMessage(null, new CertResponse[] {
+            new CertResponse(new ASN1Integer(77), new PKIStatusInfo(PKIStatus.rejection))
+        }));
+        validatorUnderTest.validate(new PKIMessage(null, bodyToTest));
+    }
+
+    @Test(expected = CmpValidationException.class)
+    public void testTwoResponsesInResponse() throws BaseCmpException {
+        PKIBody bodyToTest = new PKIBody(PKIBody.TYPE_CERT_REP, new CertRepMessage(null, new CertResponse[] {
+            new CertResponse(new ASN1Integer(0), new PKIStatusInfo(PKIStatus.rejection)),
+            new CertResponse(new ASN1Integer(0), new PKIStatusInfo(PKIStatus.rejection))
+        }));
+        validatorUnderTest.validate(new PKIMessage(null, bodyToTest));
+    }
+
+    @Test(expected = CmpEnrollmentException.class)
+    public void testMissingTemplatInRequeste() throws BaseCmpException {
+        PKIBody bodyToTest = new PKIBody(
+                PKIBody.TYPE_CERT_REQ, new CertReqMessages(new CertReqMsg(new CertRequest(0, null, null), null, null)));
+        validatorUnderTest.validate(new PKIMessage(null, bodyToTest));
+    }
+
+    @Test(expected = CmpValidationException.class)
+    public void testBrokenPkiStatusInError() throws BaseCmpException {
+        PKIBody bodyToTest = new PKIBody(
+                PKIBody.TYPE_ERROR,
+                new ErrorMsgContent(new PKIStatusInfo(PKIStatus.granted, null, new PKIFailureInfo(77))));
+        validatorUnderTest.validate(new PKIMessage(null, bodyToTest));
+    }
+
+    @Test
+    public void testNegativeRevRep() throws BaseCmpException {
+        PKIBody bodyToTest = new PKIBody(
+                PKIBody.TYPE_REVOCATION_REP,
+                (new RevRepContentBuilder().add(new PKIStatusInfo(PKIStatus.rejection))).build());
+        validatorUnderTest.validate(new PKIMessage(null, bodyToTest));
+    }
+}

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/framework/CmpCaMock.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/framework/CmpCaMock.java
@@ -117,7 +117,6 @@ public class CmpCaMock implements CmpRaComponent.UpstreamExchange {
                 try {
                     v3CertBldr.addExtension(extensionsFromTemplate.getExtension(oid));
                 } catch (final CertIOException e) {
-                    // TODO Auto-generated catch block
                     e.printStackTrace();
                 }
             });

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/framework/ConfigurationFactory.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/framework/ConfigurationFactory.java
@@ -436,6 +436,7 @@ public class ConfigurationFactory {
                                 case "certProfileForKur":
                                 case "certProfileForRr":
                                 case "refuseMeRr":
+                                case "refuseMeWithExceptionRR":
                                     return enrollmentTrust;
                             }
                         }
@@ -508,6 +509,14 @@ public class ConfigurationFactory {
                         certProfile,
                         MessageDumper.msgTypeAsString(bodyType));
 
+                if ("refuseMeWithException".equals(certProfile)) {
+                    throw new RuntimeException("intended inventory config error");
+                }
+
+                if ("refuseMeWithExceptionRR".equals(certProfile)) {
+                    throw new RuntimeException("intended inventory config error");
+                }
+
                 if ("refuseMeCr".equals(certProfile)) {
                     return new InventoryInterface() {
 
@@ -528,6 +537,32 @@ public class ConfigurationFactory {
                                 @Override
                                 public boolean isGranted() {
                                     return false;
+                                }
+                            };
+                        }
+                    };
+                }
+
+                if ("updateTemplateCr".equals(certProfile)) {
+                    return new InventoryInterface() {
+
+                        @Override
+                        public CheckAndModifyResult checkAndModifyCertRequest(
+                                byte[] transactionID,
+                                String requesterDn,
+                                byte[] certTemplate,
+                                String requestedSubjectDn,
+                                byte[] pkiMessage) {
+                            return new CheckAndModifyResult() {
+
+                                @Override
+                                public byte[] getUpdatedCertTemplate() {
+                                    return certTemplate;
+                                }
+
+                                @Override
+                                public boolean isGranted() {
+                                    return true;
                                 }
                             };
                         }

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/framework/HeaderProviderForTest.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/framework/HeaderProviderForTest.java
@@ -37,7 +37,7 @@ import org.bouncycastle.asn1.x509.GeneralName;
 /**
  *
  */
-public final class HeaderProviderForTest implements HeaderProvider {
+public class HeaderProviderForTest implements HeaderProvider {
     final ASN1OctetString transactionId;
     final ASN1OctetString senderNonce = new DEROctetString(CertUtility.generateRandomBytes(16));
 

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/framework/TrustChainAndPrivateKey.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/framework/TrustChainAndPrivateKey.java
@@ -20,6 +20,8 @@ package com.siemens.pki.cmpracomponent.test.framework;
 import com.siemens.pki.cmpracomponent.configuration.SignatureCredentialContext;
 import com.siemens.pki.cmpracomponent.cryptoservices.AlgorithmHelper;
 import com.siemens.pki.cmpracomponent.protection.ProtectionProvider;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.security.Key;
 import java.security.KeyStore;
 import java.security.PrivateKey;
@@ -91,7 +93,7 @@ public class TrustChainAndPrivateKey implements SignatureCredentialContext {
         return new ProtectionProvider() {
 
             @Override
-            public List<CMPCertificate> getProtectingExtraCerts() throws Exception {
+            public List<CMPCertificate> getProtectingExtraCerts() throws GeneralSecurityException {
                 final List<CMPCertificate> ret = new ArrayList<>(trustChain.size());
                 ret.add(certificate);
                 for (final X509Certificate aktCert : trustChain) {
@@ -110,7 +112,8 @@ public class TrustChainAndPrivateKey implements SignatureCredentialContext {
             }
 
             @Override
-            public DERBitString getProtectionFor(final ProtectedPart protectedPart) throws Exception {
+            public DERBitString getProtectionFor(final ProtectedPart protectedPart)
+                    throws GeneralSecurityException, IOException {
                 final Signature sig = Signature.getInstance(AlgorithmHelper.getSigningAlgNameFromKey(privateKey));
                 sig.initSign(privateKey);
                 sig.update(protectedPart.getEncoded(ASN1Encoding.DER));


### PR DESCRIPTION
## Description

for protection of downstream NESTED messages sometimes the wrong credentials are used

## Related Issue

#111 

## Motivation and Context

#111

## How Has This Been Tested?

JUnit test, JUNIT tests in https://github.com/siemens/LightweightCmpRa/
