### PR TITLE
fix: incorrect length parameter for PBMAC1

### DIFF
--- a/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/PBMAC1ProtectionValidator.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/msgvalidation/PBMAC1ProtectionValidator.java
@@ -73,7 +73,7 @@ public class PBMAC1ProtectionValidator extends MacValidator {
                     new String(passwordAsBytes).toCharArray(),
                     params.getSalt(),
                     params.getIterationCount().intValue(),
-                    params.getKeyLength().intValue()));
+                    params.getKeyLength().intValue() * 8));
             final WrappedMac mac =
                     WrappedMacFactory.createWrappedMac(pbmac1Params.getMessageAuthScheme(), key.getEncoded());
             final byte[] protectedBytes = new ProtectedPart(header, message.getBody()).getEncoded(ASN1Encoding.DER);

--- a/src/main/java/com/siemens/pki/cmpracomponent/protection/PBMAC1Protection.java
+++ b/src/main/java/com/siemens/pki/cmpracomponent/protection/PBMAC1Protection.java
@@ -71,7 +71,7 @@ public class PBMAC1Protection extends MacProtection {
                 AlgorithmHelper.convertSharedSecretToPassword(config.getSharedSecret()),
                 salt,
                 config.getIterationCount(),
-                keyLength));
+                keyLength * 8));
         final AlgorithmIdentifier messageAuthScheme =
                 new AlgorithmIdentifier(AlgorithmHelper.getOidForMac(ConfigLogger.log(
                         interfaceName, "SharedSecretCredentialContext.getMacAlgorithm()", config::getMacAlgorithm)));


### PR DESCRIPTION
(Provide a general summary of your changes in the Title above.)

## Description

As described in https://github.com/siemens/cmp-ra-component/issues/137 the key length in context of  PBMAC1 based protection is sometimes given in bytes/octets and sometimes given in bits. 

