### PR TITLE
Fix/157 fix bc oid and spotless update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<parent.basedir>.</parent.basedir>
-		<spotless.version>2.46.1</spotless.version>
+		<spotless.version>3.1.0</spotless.version>
 		<jacoco.version>0.8.13</jacoco.version>
 		<source.version>3.3.1</source.version>
 		<maven.compiler.source>17</maven.compiler.source>
@@ -118,7 +118,7 @@
 							<include>src/test/java/**/*.java</include>
 						</includes>
 						<palantirJavaFormat>
-							<version>2.39.0</version>
+							<version>2.83.0</version>
 						</palantirJavaFormat>
 						<importOrder />
 						<removeUnusedImports />

--- a/src/test/java/com/siemens/pki/cmpclientcomponent/test/TestSignatureBasedCrWithAllKeyTypesMixed.java
+++ b/src/test/java/com/siemens/pki/cmpclientcomponent/test/TestSignatureBasedCrWithAllKeyTypesMixed.java
@@ -24,7 +24,6 @@ import java.security.KeyPairGenerator;
 import java.util.Arrays;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.iana.IANAObjectIdentifiers;
-import org.bouncycastle.asn1.misc.MiscObjectIdentifiers;
 import org.bouncycastle.asn1.nist.NISTObjectIdentifiers;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/src/test/java/com/siemens/pki/cmpracomponent/test/framework/TcAlgs.java
+++ b/src/test/java/com/siemens/pki/cmpracomponent/test/framework/TcAlgs.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.List;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.iana.IANAObjectIdentifiers;
-import org.bouncycastle.asn1.misc.MiscObjectIdentifiers;
 import org.bouncycastle.asn1.nist.NISTObjectIdentifiers;
 
 /**
@@ -66,7 +65,7 @@ public class TcAlgs {
             {
                 "MLDSA44-RSA2048-PKCS15-SHA256",
                 KeyPairGeneratorFactory.getGenericKeyPairGenerator(
-                    IANAObjectIdentifiers.id_MLDSA44_RSA2048_PKCS15_SHA256)
+                        IANAObjectIdentifiers.id_MLDSA44_RSA2048_PKCS15_SHA256)
             },
             {
                 "MLDSA44-ECDSA-P256-SHA256",


### PR DESCRIPTION
## Description
Update BC dependency from 1.81 to 1.83 and this cause further consequences with object id in BC. 

## Related Issue

#157 

## Motivation and Context
Fix the issue caused by dependency update.

## How Has This Been Tested?

Tested by JUnit tests and CI/CD.