### PR TITLE
chore: Change maven-jar-plugin version from 3.5.0 to 3.4.2 - Eclipse fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.5.0</version>
+				<version>3.4.2</version>
 				<configuration>
 					<archive>
 						<manifest>


### PR DESCRIPTION
## Description
I wish to stay on version 3.4.2 until Eclipse m2e makes a fix for v3.5.0.

## Related Issue
#162 

## Motivation and Context

Be able to use Eclipse.

## How Has This Been Tested?

Ci/CD plus Junit.
