### PR TITLE
Change URL for MavenCentral publishing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
 				<extensions>true</extensions>
 				<configuration>
 					<serverId>ossrh</serverId>
-					<nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+					<nexusUrl>https://ossrh-staging-api.central.sonatype.com</nexusUrl>
 					<autoReleaseAfterClose>false</autoReleaseAfterClose>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
SonaType chaged some things in their infrastructure; this change is required to follow the new process.